### PR TITLE
Fixed deletion's not displaying when collaboratively editing

### DIFF
--- a/collab-service/internal/hub/hub.go
+++ b/collab-service/internal/hub/hub.go
@@ -152,14 +152,14 @@ func (h *Hub) seedClient(doc *Document, c *client.Client) {
 		}
 		payload := remaining[:length]
 		remaining = remaining[length:]
-		c.Send <- payload
+		c.Send <- yjs.WrapSyncStep2(payload)
 		seedCount++
 	}
 	log.Printf("[%s] sent %d seed entries to %s\n", doc.ID, seedCount, c.UserID)
 
 	// Send in-memory updates (already individual payloads)
 	for i, payload := range updates {
-		c.Send <- payload
+		c.Send <- yjs.WrapSyncUpdate(payload)
 		log.Printf("[%s] replayed update %d/%d (%d bytes) to %s\n",
 			doc.ID, i+1, len(updates), len(payload), c.UserID)
 	}
@@ -257,8 +257,11 @@ func (h *Hub) HandleMessage(c *client.Client, msg []byte) {
 	}
 }
 
-// BroadcastPayload sends raw Yjs update bytes to every client except the sender.
+// BroadcastPayload sends wrapped Yjs update bytes to every client except the sender.
 func BroadcastPayload(doc *Document, sender *client.Client, payload []byte) {
+	// Wrap update in evnvelope
+	wrapped := yjs.WrapSyncUpdate(payload)
+
 	doc.mu.RLock()
 	defer doc.mu.RUnlock()
 
@@ -267,7 +270,7 @@ func BroadcastPayload(doc *Document, sender *client.Client, payload []byte) {
 			continue
 		}
 		select {
-		case peer.Send <- payload:
+		case peer.Send <- wrapped:
 		default:
 			log.Printf("[%s] dropped payload for slow peer %s\n", doc.ID, peer.UserID)
 		}

--- a/collab-service/internal/yjs/encode.go
+++ b/collab-service/internal/yjs/encode.go
@@ -9,3 +9,12 @@ func WrapSyncStep2(payload []byte) []byte {
 	copy(out[2:], payload)
 	return out
 }
+
+// WrapSyncUpdate wraps a raw Yjs update payload as a sync update message.
+func WrapSyncUpdate(payload []byte) []byte {
+	out := make([]byte, 2+len(payload))
+	out[0] = MsgSync
+	out[1] = SyncUpdate
+	copy(out[2:], payload)
+	return out
+}

--- a/frontend/src/api/session.js
+++ b/frontend/src/api/session.js
@@ -58,6 +58,8 @@ export function createCollabSession({ fileId, projectId, token, onStatus }) {
 
       const outerType = msg[0];
 
+      console.log(`[collab:${fileId}] raw msg — length=${msg.length} outer=${outerType} second=${msg[1]}`);
+
       if (outerType === 0) {
         // MsgSync — check inner type
         if (msg.length < 2) return;
@@ -66,19 +68,13 @@ export function createCollabSession({ fileId, projectId, token, onStatus }) {
 
         if (innerType === 1) {
           // SyncStep2 — this is the compact snapshot, strip envelope and apply
-          console.log(`[collab:${fileId}] applying snapshot (${payload.length} bytes)`);
+          console.log(`[collab:${fileId}] applying SyncStep2 snapshot (${payload.length} bytes)`);
           Y.applyUpdate(ydoc, payload, 'remote');
         } else if (innerType === 2) {
           // SyncUpdate — incremental update, payload only
           console.log(`[collab:${fileId}] applying update (${payload.length} bytes)`);
           Y.applyUpdate(ydoc, payload, 'remote');
         }
-        // SyncStep1 (innerType === 0) — server would never send this to us, ignore
-
-      } else {
-        // No envelope — raw update payload (existing update log entries)
-        console.log(`[collab:${fileId}] applying raw payload (${msg.length} bytes)`);
-        Y.applyUpdate(ydoc, msg, 'remote');
       }
     };
 

--- a/frontend/src/components/Editor/AIPanel/AIPanel.css
+++ b/frontend/src/components/Editor/AIPanel/AIPanel.css
@@ -497,3 +497,173 @@
 @keyframes spin {
   to { transform: rotate(360deg); }
 }
+
+/* ─── Markdown rendering in assistant messages ──────────────────────────── */
+
+.ai-message-markdown {
+  padding: 0 !important;
+  background: transparent !important;
+}
+
+.ai-message-markdown > * {
+  margin: 0;
+  padding: 9px 13px;
+}
+
+.ai-message-markdown > *:first-child {
+  padding-top: 9px;
+  border-radius: 6px 6px 0 0;
+  background: var(--bg-tertiary, #dddddd);
+  color: var(--text-primary, #d4d4d4);
+}
+
+.ai-message-markdown > *:last-child {
+  padding-bottom: 9px;
+  border-radius: 0 0 2px 6px;
+  background: var(--bg-tertiary, #dddddd);
+  color: var(--text-primary, #d4d4d4);
+}
+
+.ai-message-markdown > p,
+.ai-message-markdown > ul,
+.ai-message-markdown > ol,
+.ai-message-markdown > blockquote,
+.ai-message-markdown > table {
+  background: var(--bg-tertiary, #dddddd);
+  color: var(--text-primary, #d4d4d4);
+  padding: 9px 13px;
+  margin: 0;
+}
+
+/* Headings */
+.ai-md-h1,
+.ai-md-h2,
+.ai-md-h3,
+.ai-md-h4,
+.ai-md-h5,
+.ai-md-h6 {
+  margin: 12px 0 8px;
+  font-weight: 600;
+  color: var(--text-primary, #e8e8e8);
+  background: var(--bg-tertiary, #dddddd);
+  padding: 9px 13px;
+}
+
+.ai-md-h1 { font-size: 18px; }
+.ai-md-h2 { font-size: 16px; }
+.ai-md-h3 { font-size: 14px; }
+.ai-md-h4 { font-size: 13px; }
+.ai-md-h5 { font-size: 12px; }
+.ai-md-h6 { font-size: 11px; }
+
+/* Paragraphs */
+.ai-md-p {
+  line-height: 1.55;
+  margin: 0;
+}
+
+/* Lists */
+.ai-md-ul,
+.ai-md-ol {
+  padding-left: 22px;
+  margin: 6px 0;
+  background: var(--bg-tertiary, #dddddd);
+}
+
+.ai-md-li {
+  margin: 3px 0;
+  line-height: 1.55;
+}
+
+/* Code */
+.ai-inline-code {
+  font-family: 'Cascadia Code', 'Fira Code', 'Consolas', monospace;
+  font-size: 12px;
+  background: rgba(0, 0, 0, 0.2);
+  padding: 1px 4px;
+  border-radius: 3px;
+  color: #ce9178;
+}
+
+.ai-code-block {
+  margin: 6px 0 !important;
+  border-radius: 4px;
+  font-size: 12px !important;
+  overflow-x: auto;
+}
+
+.ai-code-block pre {
+  background: var(--bg-code, #1a1a1a) !important;
+  border: 1px solid var(--border, #3c3c3c) !important;
+  padding: 10px 12px !important;
+  margin: 0 !important;
+  border-radius: 4px !important;
+}
+
+.ai-code-block code {
+  background: none !important;
+  padding: 0 !important;
+  color: inherit !important;
+}
+
+/* Blockquotes */
+.ai-md-blockquote {
+  border-left: 3px solid var(--accent, #0e639c);
+  padding-left: 12px;
+  margin: 6px 0;
+  color: var(--text-secondary, #b0b0b0);
+  font-style: italic;
+  background: var(--bg-tertiary, #dddddd);
+}
+
+/* Links */
+.ai-md-link {
+  color: var(--accent, #0e639c);
+  text-decoration: none;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+
+.ai-md-link:hover {
+  text-decoration: underline;
+  opacity: 0.8;
+}
+
+/* Horizontal rule */
+.ai-md-hr {
+  border: none;
+  border-top: 1px solid var(--border, #3c3c3c);
+  margin: 12px 0;
+  background: var(--bg-tertiary, #dddddd);
+}
+
+/* Tables */
+.ai-md-table {
+  border-collapse: collapse;
+  margin: 12px 0;
+  width: 100%;
+  font-size: 12px;
+  background: var(--bg-tertiary, #dddddd);
+}
+
+.ai-md-thead {
+  background: rgba(0, 0, 0, 0.15);
+  font-weight: 600;
+}
+
+.ai-md-th,
+.ai-md-td {
+  border: 1px solid var(--border, #3c3c3c);
+  padding: 6px 8px;
+  text-align: left;
+}
+
+.ai-md-tr:nth-child(even) {
+  background: rgba(0, 0, 0, 0.05);
+}
+
+/* Strikethrough */
+.ai-md-del {
+  text-decoration: line-through;
+  opacity: 0.7;
+}

--- a/frontend/src/components/Editor/AIPanel/MessageList.jsx
+++ b/frontend/src/components/Editor/AIPanel/MessageList.jsx
@@ -1,10 +1,53 @@
 /**
  * MessageList
  *
- * Renders the conversation history plus a live streaming message if one is
- * in progress. Uses simple pre-wrap rendering; no markdown parser dependency.
+ * Renders the conversation history with full markdown support.
+ * Uses react-markdown for parsing and react-syntax-highlighter for code blocks.
  */
+import { useState, useEffect, useRef } from 'react';
+import ReactMarkdown from 'react-markdown';
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
+import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
+import remarkGfm from 'remark-gfm';
+
+
 const MessageList = ({ messages, loading, streamBuffer, streaming, bottomRef }) => {
+  const prevBufferRef = useRef('');
+  const scrollTimeout = useRef(null);
+  const containerRef = useRef(null);
+  const [shouldAutoScroll, setShouldAutoScroll] = useState(true);
+
+  // Detect scrolling
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    const handleScroll = () => {
+      const nearBottom =
+        el.scrollHeight - el.scrollTop - el.clientHeight < 100;
+
+      setShouldAutoScroll(nearBottom);
+    };
+
+    el.addEventListener('scroll', handleScroll);
+    return () => el.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  useEffect(() => {
+    if (!shouldAutoScroll) return;
+    if (!streamBuffer) return;
+
+    if (
+      streamBuffer.includes('\n') &&
+      !prevBufferRef.current.endsWith('\n')
+    ) {
+      bottomRef.current?.scrollIntoView({ behavior: 'auto' });
+    }
+
+    prevBufferRef.current = streamBuffer;
+  }, [streamBuffer, shouldAutoScroll]);
+  
+  
   if (loading) {
     return (
       <div className="ai-panel-loading">
@@ -17,7 +60,7 @@ const MessageList = ({ messages, loading, streamBuffer, streaming, bottomRef }) 
   const allEmpty = messages.length === 0 && !streaming;
 
   return (
-    <div className="ai-message-list">
+    <div className="ai-message-list" ref={containerRef}>
       {allEmpty && (
         <div className="ai-empty-state">
           <p style={{ opacity: 0.5, fontSize: 12 }}>Send a message to get started.</p>
@@ -32,8 +75,13 @@ const MessageList = ({ messages, loading, streamBuffer, streaming, bottomRef }) 
       {streaming && streamBuffer && (
         <div className="ai-message assistant">
           <span className="ai-message-role">Assistant</span>
-          <div className="ai-message-bubble">
-            {streamBuffer}
+          <div className="ai-message-bubble ai-message-markdown">
+            <ReactMarkdown
+              remarkPlugins={[remarkGfm]}
+              components={markdownComponents}
+            >
+              {streamBuffer}
+            </ReactMarkdown>
             <span className="ai-stream-cursor" />
           </div>
         </div>
@@ -55,51 +103,112 @@ const MessageList = ({ messages, loading, streamBuffer, streaming, bottomRef }) 
 };
 
 /**
- * Single message bubble. Does a minimal pass to render code blocks as <pre>.
+ * Single message bubble with markdown support.
  */
 const Message = ({ role, content }) => {
-  const parts = renderContent(content);
+  const isAssistant = role === 'assistant';
 
   return (
     <div className={`ai-message ${role}`}>
       <span className="ai-message-role">
-        {role === 'user' ? 'You' : 'Assistant'}
+        {isAssistant ? 'Assistant' : 'You'}
       </span>
-      <div className="ai-message-bubble">
-        {parts}
+      <div className={`ai-message-bubble ${isAssistant ? 'ai-message-markdown' : ''}`}>
+        {isAssistant ? (
+          <ReactMarkdown
+            remarkPlugins={[remarkGfm]}
+            components={markdownComponents}
+          >
+            {content}
+          </ReactMarkdown>
+        ) : (
+          // User messages: plain text, no markdown parsing needed
+          <span style={{ whiteSpace: 'pre-wrap' }}>{content}</span>
+        )}
       </div>
     </div>
   );
 };
 
 /**
- * Very lightweight renderer: splits on ```...``` code fences and renders
- * them as <pre><code> blocks. Everything else is plain text.
+ * Custom markdown component overrides for styled rendering.
+ * Integrates with your existing CSS design system.
  */
-function renderContent(text) {
-  const parts = [];
-  const fenceRe = /```(\w*)\n?([\s\S]*?)```/g;
-  let last = 0;
-  let match;
-  let key = 0;
+const markdownComponents = {
+  // Code blocks with syntax highlighting
+  code({ node, inline, className, children, ...props }) {
+    const match = /language-(\w+)/.exec(className || '');
+    const language = match ? match[1] : 'text';
 
-  while ((match = fenceRe.exec(text)) !== null) {
-    if (match.index > last) {
-      parts.push(<span key={key++}>{text.slice(last, match.index)}</span>);
+    if (inline) {
+      return (
+        <code className="ai-inline-code" {...props}>
+          {children}
+        </code>
+      );
     }
-    parts.push(
-      <pre key={key++}>
-        <code>{match[2]}</code>
-      </pre>
+
+    return (
+      <SyntaxHighlighter
+        style={vscDarkPlus}
+        language={language}
+        PreTag="pre"
+        CodeTag="code"
+        className="ai-code-block"
+        showLineNumbers={false}
+        wrapLines={false}
+        {...props}
+      >
+        {String(children).replace(/\n$/, '')}
+      </SyntaxHighlighter>
     );
-    last = match.index + match[0].length;
-  }
+  },
 
-  if (last < text.length) {
-    parts.push(<span key={key++}>{text.slice(last)}</span>);
-  }
+  // Headings
+  h1: ({ children }) => <h1 className="ai-md-h1">{children}</h1>,
+  h2: ({ children }) => <h2 className="ai-md-h2">{children}</h2>,
+  h3: ({ children }) => <h3 className="ai-md-h3">{children}</h3>,
+  h4: ({ children }) => <h4 className="ai-md-h4">{children}</h4>,
+  h5: ({ children }) => <h5 className="ai-md-h5">{children}</h5>,
+  h6: ({ children }) => <h6 className="ai-md-h6">{children}</h6>,
 
-  return parts;
-}
+  // Paragraphs
+  p: ({ children }) => <p className="ai-md-p">{children}</p>,
+
+  // Lists
+  ul: ({ children }) => <ul className="ai-md-ul">{children}</ul>,
+  ol: ({ children }) => <ol className="ai-md-ol">{children}</ol>,
+  li: ({ children }) => <li className="ai-md-li">{children}</li>,
+
+  // Blockquotes
+  blockquote: ({ children }) => (
+    <blockquote className="ai-md-blockquote">{children}</blockquote>
+  ),
+
+  // Links
+  a: ({ href, children }) => (
+    <a href={href} className="ai-md-link" target="_blank" rel="noopener noreferrer">
+      {children}
+    </a>
+  ),
+
+  // Horizontal rule
+  hr: () => <hr className="ai-md-hr" />,
+
+  // Tables (from remark-gfm)
+  table: ({ children }) => <table className="ai-md-table">{children}</table>,
+  thead: ({ children }) => <thead className="ai-md-thead">{children}</thead>,
+  tbody: ({ children }) => <tbody className="ai-md-tbody">{children}</tbody>,
+  tr: ({ children }) => <tr className="ai-md-tr">{children}</tr>,
+  th: ({ children }) => <th className="ai-md-th">{children}</th>,
+  td: ({ children }) => <td className="ai-md-td">{children}</td>,
+
+  // Emphasis
+  strong: ({ children }) => <strong>{children}</strong>,
+  em: ({ children }) => <em>{children}</em>,
+
+  // Strikethrough (from remark-gfm)
+  del: ({ children }) => <del className="ai-md-del">{children}</del>,
+};
 
 export default MessageList;


### PR DESCRIPTION
# Wrapped All Messages in Envelope

All Yjs messages now wrapped in envelope, instead of defaulting to raw payload sometimes. Byte collisions between payloads and message types were occurring, causing deletions to not display or persist when in collaborative edit mode. 

## Issues Fixed by this Update

- Deletions now display across clients when editing collaboratively

- Deleting content in collaborative mode no longer causes document load to fail

