### PR TITLE
Build/file data service prod image

### DIFF
--- a/.agent/skills/create-prod-dockerfile/SKILL.md
+++ b/.agent/skills/create-prod-dockerfile/SKILL.md
@@ -9,6 +9,7 @@ Use this skill when asked to create or update a production Dockerfile for a serv
 3. If a matching language-specific instruction file exists in `resources/`, read it and apply it after the baseline conventions.
    - `resources/fastapi.md` for Python FastAPI/Uvicorn services.
    - `resources/go.md` for Go services.
+   - `resources/rust.md` for Rust services.
 4. Treat language-specific instructions as higher priority than generic conventions when they conflict.
 5. Inspect the target service before editing so the Dockerfile matches the actual build command, dependency manager, module path, application entry point, port, health endpoint, and runtime needs.
 6. If the service has a `Dockerfile.dev`, read it for discovery only: entry point, port, dependency manager, build commands, working directory, and service-specific environment defaults. Do not copy dev-only patterns into the production Dockerfile unless they are explicitly appropriate for production.

--- a/.agent/skills/create-prod-dockerfile/resources/rust.md
+++ b/.agent/skills/create-prod-dockerfile/resources/rust.md
@@ -1,0 +1,247 @@
+## Rust (Tokio / tonic gRPC)
+
+### Base images
+
+**Builder:** `rust:1.XX-bookworm` (pin to the same Rust version used in the project)
+
+**Runtime:** `gcr.io/distroless/cc-debian12` — the Rust binary links against a small set of C libraries (libgcc, libm) even with `--release`. `cc` distroless includes these. Do not use `distroless/static` or `scratch` unless the binary is verified 100% statically linked (requires musl target, see note below).
+
+If a fully static binary is needed, compile against `x86_64-unknown-linux-musl` / `aarch64-unknown-linux-musl` and use `distroless/static-debian12` or `scratch` as the runtime. This requires adding the musl target and a C cross-compiler — only do this if the project already supports it.
+
+### System dependencies
+
+tonic gRPC services require `protobuf-compiler` at build time to compile `.proto` files. This must be installed in the builder stage only — it is never needed at runtime.
+
+If the service uses TLS (`rustls` is pure-Rust and needs nothing; `native-tls` requires `libssl-dev` at build time and `libssl3` at runtime):
+- Prefer `rustls` for zero-runtime-dependency TLS
+- If `native-tls` is required, install `libssl3` in the runtime stage via a minimal apt step
+
+```dockerfile
+# Builder: proto compiler + any C build deps
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    protobuf-compiler \
+    pkg-config \
+    libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+```
+
+### Proto files
+
+If the service consumes a shared `.proto` definition from outside its own directory (e.g. a monorepo root `proto/` directory), it must be passed in via BuildKit `additional_contexts` — the same pattern used in the dev Dockerfile:
+
+```yaml
+# docker-compose.yml
+build:
+  context: ./my-service
+  additional_contexts:
+    root-proto: ./proto
+```
+
+```dockerfile
+# Dockerfile
+COPY --from=root-proto . ./proto
+```
+
+This pattern must be preserved exactly in the production Dockerfile. Do not inline proto files or change the mount path without confirming the `build.rs` proto include paths are updated accordingly.
+
+### Dependency caching
+
+Rust compile times are long. Cache dependencies by copying manifests and a stub `main.rs` first, building dependencies only, then removing the stub artifacts before the real build. This is the standard Rust Docker caching pattern:
+
+```dockerfile
+COPY Cargo.toml Cargo.lock ./
+COPY build.rs ./
+COPY --from=root-proto . ./proto
+
+# Stub build — caches all dependency compilation
+RUN mkdir src && echo 'fn main() {}' > src/main.rs \
+    && cargo build --release \
+    && rm -f target/release/<binary-name> \
+       target/release/<binary-name>.d \
+    && rm -rf target/.fingerprint/<binary-name>-* \
+    && rm -rf src
+```
+
+**The stub cleanup step is mandatory.** Without removing the stub binary and its fingerprint, Cargo will not recompile `main.rs` when the real source is copied in — it sees the dependency timestamps as satisfied. Remove:
+- `target/release/<binary-name>` — the stub binary
+- `target/release/<binary-name>.d` — the dep file
+- `target/.fingerprint/<binary-name>-*` — the fingerprint dir (glob)
+
+Replace `<binary-name>` with the actual binary name from `Cargo.toml` `[[bin]]` or the package name.
+
+Use `--mount=type=cache` for the cargo registry and build cache to avoid re-downloading crates across builds:
+
+```dockerfile
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/app/target \
+    cargo build --release
+```
+
+Note: `--mount=type=cache` on `target/` requires that the binary be copied out of the cache mount before the layer completes, since cache mounts are not preserved in the image layer:
+
+```dockerfile
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/app/target \
+    cargo build --release \
+    && cp target/release/<binary-name> /app/server
+```
+
+### Release build flags
+
+Always build with `--release`. Optionally add to `Cargo.toml` for smaller binaries:
+
+```toml
+[profile.release]
+strip = true       # strips symbols (equivalent to -s in Go ldflags)
+opt-level = 3
+lto = true         # link-time optimization, slower build but smaller/faster binary
+codegen-units = 1  # maximizes LTO effectiveness
+```
+
+If `strip = true` is set in `Cargo.toml`, do not also run `strip` as a separate step.
+
+### SIGTERM
+
+Tokio handles OS signals via `tokio::signal`. SIGTERM handling **requires explicit wiring in application code** — it is not automatic. The gRPC server must listen for SIGTERM and call shutdown on the tonic `Server`.
+
+Add a comment in the generated Dockerfile:
+
+```dockerfile
+# NOTE: This service requires SIGTERM handling in application code.
+# Use tokio::signal::unix::signal(SignalKind::terminate()) to listen for
+# SIGTERM and trigger graceful server shutdown via tonic Server shutdown hooks.
+# Without this, the process receives SIGKILL after the orchestrator grace period.
+STOPSIGNAL SIGTERM
+```
+
+### gRPC port
+
+gRPC conventionally runs on port 50051. Set via environment variable consistent with the dev Dockerfile:
+
+```dockerfile
+ENV GRPC_ADDR="[::]:50051"
+EXPOSE 50051
+```
+
+The `[::]:50051` binding listens on all IPv4 and IPv6 interfaces — correct for containerised services.
+
+### Healthcheck
+
+Distroless has no shell or curl. For gRPC services, use one of:
+
+1. **gRPC health protocol** (preferred) — implement the standard `grpc.health.v1.Health` service in the application. Use a compiled `grpc_health_probe` binary:
+```dockerfile
+COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:latest /ko-app/grpc-health-probe /bin/grpc_health_probe
+HEALTHCHECK --interval=15s --timeout=5s --start-period=10s --retries=3 \
+    CMD ["/bin/grpc_health_probe", "-addr=:50051"]
+```
+
+2. **Self-contained healthcheck flag** — implement a `-healthcheck` CLI flag in the binary that performs the check and exits 0/1. Reference it in exec-form CMD:
+```dockerfile
+HEALTHCHECK --interval=15s --timeout=5s --start-period=10s --retries=3 \
+    CMD ["/app/server", "-healthcheck"]
+```
+
+3. **Separate health HTTP endpoint** — expose a lightweight HTTP `/healthz` on a separate port (e.g. 8080) alongside the gRPC port, and use curl from a sidecar or a compiled minimal binary.
+
+Option 1 is preferred for gRPC services as it validates the gRPC stack end-to-end, not just process liveness.
+
+### Full template
+
+```dockerfile
+# syntax=docker/dockerfile:1
+
+# ── Builder ────────────────────────────────────────────────────────────────
+FROM rust:1.XX-bookworm AS builder
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    protobuf-compiler \
+    pkg-config \
+    libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Pass in shared proto directory via BuildKit additional_contexts
+COPY --from=root-proto . ./proto
+
+# Manifests + build script (cached layer)
+COPY Cargo.toml Cargo.lock ./
+COPY build.rs ./
+
+# Stub build — caches dependency compilation
+RUN mkdir src && echo 'fn main() {}' > src/main.rs \
+    && cargo build --release \
+    && rm -f target/release/<binary-name> \
+             target/release/<binary-name>.d \
+    && rm -rf target/.fingerprint/<binary-name>-* \
+    && rm -rf src
+
+# Real build
+COPY src ./src
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    cargo build --release \
+    && cp target/release/<binary-name> /app/server
+
+# ── Runtime ────────────────────────────────────────────────────────────────
+FROM gcr.io/distroless/cc-debian12 AS runtime
+
+ARG GIT_SHA=unknown
+ARG BUILD_DATE=unknown
+
+LABEL org.opencontainers.image.revision="${GIT_SHA}" \
+      org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.source="<repo-url>"
+
+COPY --from=builder /app/server /app/server
+
+# Optional: copy grpc_health_probe for healthcheck
+# COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:latest /ko-app/grpc-health-probe /bin/grpc_health_probe
+
+ENV GRPC_ADDR="[::]:50051" \
+    RUST_LOG=info
+
+USER nonroot
+
+EXPOSE 50051
+
+HEALTHCHECK --interval=15s --timeout=5s --start-period=10s --retries=3 \
+    CMD ["/app/server", "-healthcheck"]
+
+# NOTE: This service requires SIGTERM handling in application code.
+# Use tokio::signal::unix::signal(SignalKind::terminate()) and wire it into
+# tonic server shutdown. Without it, the process is SIGKILLed after the
+# orchestrator grace period with no graceful drain.
+STOPSIGNAL SIGTERM
+
+ENTRYPOINT ["/app/server"]
+```
+
+### docker-compose integration
+
+The production override must supply the `additional_contexts` for the shared proto directory. This cannot be omitted — without it the build fails at the `COPY --from=root-proto` step.
+
+```yaml
+# docker-compose.prod.yml
+services:
+  <service-name>:
+    build:
+      context: ./<service-dir>
+      dockerfile: Dockerfile
+      additional_contexts:
+        root-proto: ./proto
+    environment:
+      RUST_LOG: info
+      GRPC_ADDR: "[::]:50051"
+    restart: unless-stopped
+```
+
+### Hard rules
+
+- Always use `--release` — never ship a debug build
+- Always clean stub binary and fingerprint before the real `cargo build`
+- Never install `protobuf-compiler` or `libssl-dev` in the runtime stage
+- Never use `distroless/static` or `scratch` unless the binary is confirmed musl-linked
+- Always preserve the `--from=root-proto` pattern if the project uses a shared proto context
+- Always set `RUST_LOG=info` (not `debug`) in production — debug logging is expensive
+- Always add the SIGTERM wiring comment
+- Healthcheck must not use `curl` or `wget` — distroless has neither

--- a/file-data-service/.dockerignore
+++ b/file-data-service/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.env*
+*.log
+**/node_modules
+**/dist
+**/__pycache__
+
+.DS_Store
+Dockerfile.dev
+target/
+file-data-service/

--- a/file-data-service/Cargo.lock
+++ b/file-data-service/Cargo.lock
@@ -170,6 +170,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "compaction-service"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "futures",
+ "prost",
+ "reqwest",
+ "tokio",
+ "tokio-util",
+ "tonic",
+ "tonic-build",
+ "tracing",
+ "tracing-subscriber",
+ "yrs",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,24 +312,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 dependencies = [
  "getrandom 0.2.17",
-]
-
-[[package]]
-name = "file-data-service"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "bytes",
- "futures",
- "prost",
- "reqwest",
- "tokio",
- "tokio-util",
- "tonic",
- "tonic-build",
- "tracing",
- "tracing-subscriber",
- "yrs",
 ]
 
 [[package]]

--- a/file-data-service/Dockerfile
+++ b/file-data-service/Dockerfile
@@ -1,0 +1,144 @@
+# syntax=docker/dockerfile:1
+
+# Builder stage: compile the Rust tonic service and generate protobuf bindings.
+# The digest pins the multi-arch manifest used by Docker, including linux/arm64
+# for Raspberry Pi deployments.
+FROM rust:1.94-bookworm@sha256:6ae102bdbf528294bc79ad6e1fae682f6f7c2a6e6621506ba959f9685b308a55 AS builder
+
+WORKDIR /app
+
+# protoc is required by tonic-build. OpenSSL headers are required because
+# reqwest currently uses default native-tls features.
+RUN export DEBIAN_FRONTEND=noninteractive \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libssl-dev \
+        pkg-config \
+        protobuf-compiler \
+    && rm -rf /var/lib/apt/lists/*
+
+# The shared protobuf directory is supplied by Compose BuildKit
+# `additional_contexts` as `root-proto`. This must match build.rs, which reads
+# proto/compaction.proto from the service build context.
+COPY --from=root-proto . ./proto
+
+# Copy manifests before source so dependency compilation can be cached when only
+# application code changes. `--locked` guarantees Cargo.lock is the source of
+# truth for reproducible production builds.
+COPY Cargo.toml Cargo.lock ./
+COPY build.rs ./
+
+# Build a stub binary to warm the dependency cache. Then clean only this package
+# so Cargo cannot accidentally reuse the dummy `fn main() {}` binary after the
+# real source tree is copied in.
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/app/target \
+    mkdir src \
+    && printf 'fn main() {}\n' > src/main.rs \
+    && cargo build --release --locked \
+    && cargo clean --release -p compaction-service \
+    && rm -rf src
+
+COPY src ./src
+
+# Compile the real service and copy it out of the cache-mounted target
+# directory. Cache mounts are not persisted into image layers.
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/app/target \
+    cargo build --release --locked \
+    && cp target/release/compaction-service /app/server
+
+# Docker healthchecks cannot rely on curl/wget in minimal images. This service
+# does not currently implement the standard gRPC health protocol, so the probe
+# performs a conservative TCP liveness check against the gRPC listener.
+RUN <<'EOF'
+cat > /tmp/healthcheck.rs <<'RS'
+use std::env;
+use std::net::{SocketAddr, TcpStream};
+use std::process;
+use std::time::Duration;
+
+fn grpc_port() -> String {
+    let addr = env::var("GRPC_ADDR").unwrap_or_else(|_| "[::]:50051".to_string());
+    addr.rsplit(':')
+        .next()
+        .filter(|port| port.chars().all(|c| c.is_ascii_digit()))
+        .unwrap_or("50051")
+        .to_string()
+}
+
+fn can_connect(addr: &str) -> bool {
+    let timeout = Duration::from_secs(2);
+    match addr.parse::<SocketAddr>() {
+        Ok(socket_addr) => TcpStream::connect_timeout(&socket_addr, timeout).is_ok(),
+        Err(_) => false,
+    }
+}
+
+fn main() {
+    let port = grpc_port();
+    let ipv4 = format!("127.0.0.1:{port}");
+    let ipv6 = format!("[::1]:{port}");
+
+    if can_connect(&ipv4) || can_connect(&ipv6) {
+        process::exit(0);
+    }
+
+    process::exit(1);
+}
+RS
+
+rustc -O /tmp/healthcheck.rs -o /app/healthcheck
+EOF
+
+# Runtime stage: keep only the service binary, healthcheck helper, CA roots, and
+# OpenSSL runtime library. This uses slim Debian instead of distroless because
+# reqwest currently links native-tls/OpenSSL and needs libssl at runtime.
+FROM debian:bookworm-slim@sha256:0104b334637a5f19aa9c983a91b54c89887c0984081f2068983107a6f6c21eeb AS runtime
+
+WORKDIR /app
+
+ARG GIT_SHA=unknown
+ARG BUILD_DATE=unknown
+
+# OCI labels let CI and operators trace a built image back to its source commit.
+LABEL org.opencontainers.image.title="SyncTeX File Data Service" \
+      org.opencontainers.image.description="Rust tonic gRPC service for Yjs compaction and text export" \
+      org.opencontainers.image.source="https://github.com/ameb8/sync-tex/tree/main/file-data-service" \
+      org.opencontainers.image.revision="${GIT_SHA}" \
+      org.opencontainers.image.created="${BUILD_DATE}"
+
+# Install only runtime OS dependencies and create a dedicated unprivileged user.
+RUN export DEBIAN_FRONTEND=noninteractive \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates libssl3 \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --system appgroup \
+    && useradd --system --gid appgroup --home-dir /app --no-create-home appuser
+
+# Copy artifacts with final ownership so the runtime container never needs root
+# privileges to read or execute them.
+COPY --from=builder --chown=appuser:appgroup /app/server /app/server
+COPY --from=builder --chown=appuser:appgroup /app/healthcheck /app/healthcheck
+
+# Safe defaults for Compose production use. Secrets are intentionally excluded
+# and must be injected by the orchestrator when needed.
+ENV GRPC_ADDR="[::]:50051" \
+    RUST_LOG=info
+
+USER appuser
+
+# gRPC API port. EXPOSE is metadata only; Compose controls actual networking.
+EXPOSE 50051
+
+# The TCP probe checks that the service is accepting local gRPC connections.
+HEALTHCHECK --interval=15s --timeout=5s --start-period=10s --retries=3 \
+    CMD ["/app/healthcheck"]
+
+# NOTE: This service requires SIGTERM handling in application code.
+# Use tokio::signal::unix::signal(SignalKind::terminate()) and wire it into
+# tonic server shutdown. Without it, the process is SIGKILLed after the
+# orchestrator grace period with no graceful drain.
+STOPSIGNAL SIGTERM
+
+ENTRYPOINT ["/app/server"]


### PR DESCRIPTION
# build/file-data-service-prod-image

## Summary
- This branch packages 3 local commits across `agent` and `file-data-service`.
- It includes: ensure internal package naming conventions are consistent; add production Docker image; add Rust-specific instructions to production Dockerfile agent skill.
- File-level impact: 3 added and 2 updated.
- Implementation context: Add a multi-stage Rust Dockerfile for the file-data-service gRPC server.

## Changes
### Commits
- `87da6c2` docs(agent): add Rust-specific instructions to production Dockerfile agent skill.
- `39d8593` build(file-data-service): add production Docker image.
  Context: Add a multi-stage Rust Dockerfile for the file-data-service gRPC server.
- `a8fa5c7` build(file-data-service): ensure internal package naming conventions are consistent.

### Files
- `.agent/skills/create-prod-dockerfile/SKILL.md` (updated)
- `.agent/skills/create-prod-dockerfile/resources/rust.md` (added)
- `file-data-service/.dockerignore` (added)
- `file-data-service/Cargo.lock` (updated)
- `file-data-service/Dockerfile` (added)

## Related Issues
- Resolves #45
