### PR TITLE
Feat/display editor awareness

### DIFF
--- a/collab-service/internal/hub/hub.go
+++ b/collab-service/internal/hub/hub.go
@@ -12,9 +12,10 @@ import (
 
 // Document holds all runtime state for one open collaborative file.
 type Document struct {
-	ID      string
-	mu      sync.RWMutex
-	clients map[*client.Client]bool
+	ID        string
+	mu        sync.RWMutex
+	clients   map[*client.Client]bool
+	awareness map[*client.Client][]byte
 
 	// snapshot is a Yjs binary snapshot of document in compressed form
 	snapshot []byte
@@ -59,6 +60,12 @@ func New(
 	}
 }
 
+func cloneBytes(src []byte) []byte {
+	dst := make([]byte, len(src))
+	copy(dst, src)
+	return dst
+}
+
 // GetOrCreate returns the Document for docID, creating it if needed.
 func (h *Hub) GetOrCreate(docID string) *Document {
 	h.mu.Lock()
@@ -70,6 +77,7 @@ func (h *Hub) GetOrCreate(docID string) *Document {
 	doc := &Document{
 		ID:            docID,
 		clients:       make(map[*client.Client]bool),
+		awareness:     make(map[*client.Client][]byte),
 		seeder:        h.seederFactory(docID),
 		uploader:      h.uploaderFactory(docID),
 		debounceDelay: h.debounceDelay,
@@ -105,7 +113,18 @@ func (h *Hub) Register(c *client.Client) {
 	doc.mu.Lock()
 	doc.clients[c] = true
 	n := len(doc.clients)
+	cachedAwareness := make([][]byte, 0, len(doc.awareness))
+	for peer, msg := range doc.awareness {
+		if peer == c {
+			continue
+		}
+		cachedAwareness = append(cachedAwareness, cloneBytes(msg))
+	}
 	doc.mu.Unlock()
+
+	for _, msg := range cachedAwareness {
+		c.Send <- msg
+	}
 
 	log.Printf("[%s] %s (%s) connected — %d clients\n", c.DocID, c.UserID, c.Role, n)
 }
@@ -176,6 +195,7 @@ func (h *Hub) Unregister(c *client.Client) {
 		return
 	}
 	delete(doc.clients, c)
+	delete(doc.awareness, c)
 	remaining := len(doc.clients)
 
 	// Cancel any pending debounce before final upload
@@ -222,6 +242,10 @@ func (h *Hub) HandleMessage(c *client.Client, msg []byte) {
 	case yjs.MsgAwareness:
 		// Awareness (cursors/presence) — broadcast to all peers including viewers.
 		log.Println("[Message Type]: Awareness")
+		doc.mu.Lock()
+		doc.awareness[c] = cloneBytes(msg)
+		doc.mu.Unlock()
+
 		Broadcast(doc, c, msg)
 
 	case yjs.MsgSync:

--- a/frontend/src/api/session.js
+++ b/frontend/src/api/session.js
@@ -1,5 +1,10 @@
 import * as Y from 'yjs';
 import { MonacoBinding } from 'y-monaco';
+import {
+  Awareness,
+  applyAwarenessUpdate,
+  encodeAwarenessUpdate,
+} from 'y-protocols/awareness';
 
 
 
@@ -12,6 +17,40 @@ function getWsBase() {
 const RECONNECT_DELAY_MS = 2000;
 const MAX_RECONNECT_ATTEMPTS = 5;
 
+const AWARENESS_COLORS = [
+  '#1f80dd',
+  '#0f9f6e',
+  '#c2410c',
+  '#7c3aed',
+  '#be123c',
+  '#047857',
+  '#b45309',
+  '#2563eb',
+];
+
+function colorForUserId(id) {
+  let hash = 0;
+  for (let i = 0; i < id.length; i += 1) {
+    hash = ((hash << 5) - hash + id.charCodeAt(i)) | 0;
+  }
+  return AWARENESS_COLORS[Math.abs(hash) % AWARENESS_COLORS.length];
+}
+
+function normalizeAwarenessUser(input) {
+  const source = input ?? {};
+  const rawId = source.id ?? source.user_id ?? source.sub ?? 'local-user';
+  const id = String(rawId);
+  const email = typeof source.email === 'string' ? source.email : '';
+  const rawName = source.name || source.display_name || source.username || email || 'Local User';
+
+  return {
+    id,
+    name: String(rawName),
+    email,
+    color: typeof source.color === 'string' ? source.color : colorForUserId(id),
+  };
+}
+
 /**
  * Create a collaborative editing session for one file.
  *
@@ -21,19 +60,36 @@ const MAX_RECONNECT_ATTEMPTS = 5;
  *                                    potential future auth/routing use
  * @param {string}   opts.token     - JWT passed as a query param for auth
  * @param {function} opts.onStatus  - Called with 'connecting'|'connected'|'disconnected'
+ * @param {object=}  opts.user      - Optional authenticated user metadata
+ * @param {object=}  opts.localUser - Optional explicit awareness user metadata
  *
  * @returns {{ bindEditor, getContent, destroy }}
  */
-export function createCollabSession({ fileId, projectId, token, onStatus }) {
+export function createCollabSession({ fileId, projectId, token, onStatus, user = null, localUser = null }) {
   // Each file gets its own Y.Doc — they must not be shared across files.
   const ydoc = new Y.Doc();
   const ytext = ydoc.getText('content');
+  const awareness = new Awareness(ydoc);
+  const awarenessUser = normalizeAwarenessUser(localUser ?? user);
+  awareness.setLocalStateField('user', awarenessUser);
 
   let ws = null;
   let binding = null;        // MonacoBinding instance, set in bindEditor()
   let destroyed = false;
   let reconnectAttempts = 0;
   let reconnectTimer = null;
+
+  function sendAwarenessUpdate(clientIds) {
+    if (!ws || ws.readyState !== WebSocket.OPEN || clientIds.length === 0) {
+      return;
+    }
+
+    const update = encodeAwarenessUpdate(awareness, clientIds);
+    const msg = new Uint8Array(1 + update.length);
+    msg[0] = 1; // MsgAwareness
+    msg.set(update, 1);
+    ws.send(msg);
+  }
 
   // Connect (or reconnect) to the collab-service WebSocket.
   function connect() {
@@ -47,6 +103,7 @@ export function createCollabSession({ fileId, projectId, token, onStatus }) {
     ws.onopen = () => {
       reconnectAttempts = 0;
       onStatus('connected');
+      sendAwarenessUpdate([awareness.clientID]);
       // No handshake needed — the server sends the current document state
       // as a Yjs binary update immediately on connect. We just wait for it.
     };
@@ -75,6 +132,9 @@ export function createCollabSession({ fileId, projectId, token, onStatus }) {
           console.log(`[collab:${fileId}] applying update (${payload.length} bytes)`);
           Y.applyUpdate(ydoc, payload, 'remote');
         }
+      } else if (outerType === 1) {
+        if (msg.length < 2) return;
+        applyAwarenessUpdate(awareness, msg.slice(1), 'remote');
       }
     };
 
@@ -99,6 +159,11 @@ export function createCollabSession({ fileId, projectId, token, onStatus }) {
     console.log(`[collab:${fileId}] reconnect attempt ${reconnectAttempts}`);
     reconnectTimer = setTimeout(connect, RECONNECT_DELAY_MS);
   }
+
+  awareness.on('update', ({ added, updated, removed }, origin) => {
+    if (origin === 'remote') return;
+    sendAwarenessUpdate(added.concat(updated, removed));
+  });
 
   // Observe local Y.Doc changes and forward them to the server.
   // This fires whenever the local user edits (via MonacoBinding) or when
@@ -155,7 +220,7 @@ export function createCollabSession({ fileId, projectId, token, onStatus }) {
     // It replaces the model's content with the current Y.Doc state on attach,
     // so whatever the server sent us on connect is immediately reflected.
     console.log('[collab] creating MonacoBinding for', fileId);
-    binding = new MonacoBinding(ytext, model, new Set([editor]), null);
+    binding = new MonacoBinding(ytext, model, new Set([editor]), awareness);
     return true;
     editor.onDidChangeModelContent(() => {
       console.log('MONACO CHANGE DETECTED');
@@ -175,10 +240,16 @@ export function createCollabSession({ fileId, projectId, token, onStatus }) {
    * Called on tab close and component unmount.
    */
   function destroy() {
+    if (destroyed) return;
+    if (ws && ws.readyState === WebSocket.OPEN && awareness.getLocalState() !== null) {
+      awareness.setLocalState(null);
+    }
+
     destroyed = true;
     clearTimeout(reconnectTimer);
     if (binding) { binding.destroy(); binding = null; }
     if (ws) { ws.close(); ws = null; }
+    awareness.destroy();
     ydoc.destroy();
   }
 

--- a/frontend/src/api/session.js
+++ b/frontend/src/api/session.js
@@ -26,6 +26,14 @@ const AWARENESS_COLORS = [
   '#047857',
   '#b45309',
   '#2563eb',
+  '#db2777',
+  '#0891b2',
+  '#65a30d',
+  '#9333ea',
+  '#ea580c',
+  '#0284c7',
+  '#16a34a',
+  '#e11d48',
 ];
 
 function colorForUserId(id) {
@@ -36,18 +44,34 @@ function colorForUserId(id) {
   return AWARENESS_COLORS[Math.abs(hash) % AWARENESS_COLORS.length];
 }
 
+function isHexColor(value) {
+  return typeof value === 'string' && /^#[0-9a-f]{6}$/i.test(value);
+}
+
+function colorWithAlpha(hex, alpha) {
+  if (!isHexColor(hex)) return `rgba(31, 128, 221, ${alpha})`;
+
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
 function normalizeAwarenessUser(input) {
   const source = input ?? {};
   const rawId = source.id ?? source.user_id ?? source.sub ?? 'local-user';
   const id = String(rawId);
   const email = typeof source.email === 'string' ? source.email : '';
   const rawName = source.name || source.display_name || source.username || email || 'Local User';
+  const sourceColor = isHexColor(source.color) ? source.color : null;
+  const avatarUrl = source.avatar_url || source.avatarUrl || source.picture || '';
 
   return {
     id,
     name: String(rawName),
     email,
-    color: typeof source.color === 'string' ? source.color : colorForUserId(id),
+    avatar_url: typeof avatarUrl === 'string' ? avatarUrl : '',
+    color: sourceColor || colorForUserId(id),
   };
 }
 
@@ -63,9 +87,19 @@ function normalizeAwarenessUser(input) {
  * @param {object=}  opts.user      - Optional authenticated user metadata
  * @param {object=}  opts.localUser - Optional explicit awareness user metadata
  *
- * @returns {{ bindEditor, getContent, destroy }}
+ * @param {function=} opts.onAwarenessChange - Called with live awareness users
+ *
+ * @returns {{ bindEditor, getContent, destroy, getAwarenessUsers }}
  */
-export function createCollabSession({ fileId, projectId, token, onStatus, user = null, localUser = null }) {
+export function createCollabSession({
+  fileId,
+  projectId,
+  token,
+  onStatus,
+  onAwarenessChange = () => {},
+  user = null,
+  localUser = null,
+}) {
   // Each file gets its own Y.Doc — they must not be shared across files.
   const ydoc = new Y.Doc();
   const ytext = ydoc.getText('content');
@@ -78,6 +112,76 @@ export function createCollabSession({ fileId, projectId, token, onStatus, user =
   let destroyed = false;
   let reconnectAttempts = 0;
   let reconnectTimer = null;
+  let awarenessStyleEl = null;
+  let lastAwarenessUsersKey = '';
+
+  function getAwarenessUsers() {
+    return Array.from(awareness.getStates().entries())
+      .map(([clientId, state]) => {
+        if (!state?.user) return null;
+
+        return {
+          clientId,
+          fileId,
+          isLocal: clientId === awareness.clientID,
+          user: normalizeAwarenessUser(state.user),
+        };
+      })
+      .filter(Boolean);
+  }
+
+  function getAwarenessUsersKey(users) {
+    return JSON.stringify(users.map(({ clientId, isLocal, user }) => ({
+      clientId,
+      isLocal,
+      id: user.id,
+      name: user.name,
+      email: user.email,
+      avatar_url: user.avatar_url,
+      color: user.color,
+    })));
+  }
+
+  function updateAwarenessStyles(users) {
+    if (typeof document === 'undefined') return;
+
+    const styles = users
+      .filter(({ isLocal }) => !isLocal)
+      .map(({ clientId, user }) => {
+        const selectionColor = colorWithAlpha(user.color, 0.18);
+
+        return `
+.yRemoteSelection-${clientId} {
+  background-color: ${selectionColor};
+}
+
+.yRemoteSelectionHead-${clientId} {
+  border-left-color: ${user.color};
+  border-left-width: 2px;
+  border-left-style: solid;
+}
+`;
+      })
+      .join('\n');
+
+    if (!awarenessStyleEl) {
+      awarenessStyleEl = document.createElement('style');
+      awarenessStyleEl.dataset.syncTexAwareness = fileId;
+      document.head.appendChild(awarenessStyleEl);
+    }
+
+    awarenessStyleEl.textContent = styles;
+  }
+
+  function emitAwarenessChange() {
+    const users = getAwarenessUsers();
+    const usersKey = getAwarenessUsersKey(users);
+    if (usersKey === lastAwarenessUsersKey) return;
+
+    lastAwarenessUsersKey = usersKey;
+    updateAwarenessStyles(users);
+    onAwarenessChange(users);
+  }
 
   function sendAwarenessUpdate(clientIds) {
     if (!ws || ws.readyState !== WebSocket.OPEN || clientIds.length === 0) {
@@ -104,6 +208,7 @@ export function createCollabSession({ fileId, projectId, token, onStatus, user =
       reconnectAttempts = 0;
       onStatus('connected');
       sendAwarenessUpdate([awareness.clientID]);
+      emitAwarenessChange();
       // No handshake needed — the server sends the current document state
       // as a Yjs binary update immediately on connect. We just wait for it.
     };
@@ -139,6 +244,7 @@ export function createCollabSession({ fileId, projectId, token, onStatus, user =
     };
 
     ws.onclose = () => {
+      if (destroyed) return;
       onStatus('disconnected');
       scheduleReconnect();
     };
@@ -164,6 +270,8 @@ export function createCollabSession({ fileId, projectId, token, onStatus, user =
     if (origin === 'remote') return;
     sendAwarenessUpdate(added.concat(updated, removed));
   });
+
+  awareness.on('change', emitAwarenessChange);
 
   // Observe local Y.Doc changes and forward them to the server.
   // This fires whenever the local user edits (via MonacoBinding) or when
@@ -249,6 +357,12 @@ export function createCollabSession({ fileId, projectId, token, onStatus, user =
     clearTimeout(reconnectTimer);
     if (binding) { binding.destroy(); binding = null; }
     if (ws) { ws.close(); ws = null; }
+    awareness.off('change', emitAwarenessChange);
+    if (awarenessStyleEl) {
+      awarenessStyleEl.remove();
+      awarenessStyleEl = null;
+    }
+    onAwarenessChange([]);
     awareness.destroy();
     ydoc.destroy();
   }
@@ -256,5 +370,7 @@ export function createCollabSession({ fileId, projectId, token, onStatus, user =
   // Kick off the initial connection.
   connect();
 
-  return { bindEditor, getContent, destroy };
+  emitAwarenessChange();
+
+  return { bindEditor, getContent, destroy, getAwarenessUsers };
 }

--- a/frontend/src/components/Editor/CollaboratorsPanel.css
+++ b/frontend/src/components/Editor/CollaboratorsPanel.css
@@ -81,6 +81,11 @@
   padding: 16px 0;
 }
 
+.collab-empty-compact {
+  padding: 8px 0 2px;
+  text-align: left;
+}
+
 /* Form */
 .collab-form-group {
   margin-bottom: 12px;
@@ -263,6 +268,83 @@
   text-overflow: ellipsis;
 }
 
+/* Live editors */
+.collab-live-section {
+  padding: 10px;
+}
+
+.collab-live-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.collab-live-editor {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  min-width: 0;
+  min-height: 36px;
+  padding: 6px 8px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.72), rgba(255, 255, 255, 0.36)),
+    var(--bg-sidebar, #f9f9f9);
+  border: 0.5px solid var(--border-color, #e0e0e0);
+  border-radius: 6px;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.collab-live-editor:hover {
+  background: var(--bg-primary, #ffffff);
+  border-color: color-mix(in srgb, var(--presence-color, var(--text-info, #1f80dd)) 45%, var(--border-color, #e0e0e0));
+}
+
+.collab-live-avatar {
+  width: 26px;
+  height: 26px;
+  min-width: 26px;
+  border-radius: 50%;
+  background: var(--text-info, #1f80dd);
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  font-weight: 700;
+  box-sizing: border-box;
+  border: 2px solid transparent;
+  overflow: hidden;
+}
+
+.collab-live-name {
+  margin: 0;
+  min-width: 0;
+  color: var(--text-primary, #333);
+  font-size: 12px;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.collab-avatar--live {
+  border-color: var(--presence-color);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--presence-color) 18%, transparent);
+}
+
+.collab-avatar--image {
+  background: var(--bg-primary, #ffffff);
+}
+
+.collab-member-avatar img,
+.collab-live-avatar img {
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: cover;
+  border-radius: 50%;
+}
+
 /* Members List */
 .collab-members-list {
   display: flex;
@@ -299,6 +381,9 @@
   justify-content: center;
   font-size: 12px;
   font-weight: 600;
+  box-sizing: border-box;
+  border: 2px solid transparent;
+  overflow: hidden;
   align-self: flex-start;
   margin-top: 2px;
 }
@@ -434,6 +519,21 @@
 
   .collab-link-url {
     color: var(--text-primary, #e0e0e0);
+  }
+
+  .collab-live-editor {
+    background:
+      linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.01)),
+      var(--bg-sidebar, #252526);
+    border-color: var(--border-color, #3e3e42);
+  }
+
+  .collab-live-editor:hover {
+    background: var(--bg-primary, #1e1e1e);
+  }
+
+  .collab-avatar--image {
+    background: var(--bg-sidebar, #252526);
   }
 
   .collab-member-item {

--- a/frontend/src/components/Editor/CollaboratorsPanel.jsx
+++ b/frontend/src/components/Editor/CollaboratorsPanel.jsx
@@ -1,5 +1,5 @@
 // src/components/Editor/CollaboratorsPanel.jsx
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import {
   generateCollaboratorLink,
   fetchCollaboratorLinks,
@@ -9,7 +9,50 @@ import {
 } from '../../api/collaborators';
 import './CollaboratorsPanel.css';
 
-const CollaboratorsPanel = ({ projectId }) => {
+const getPersonKeys = (person) => {
+  if (!person) return [];
+
+  return [person.user_id, person.id, person.email]
+    .filter((value) => value !== undefined && value !== null && String(value).trim() !== '')
+    .map((value) => String(value));
+};
+
+const getDisplayName = (person) => person?.name || person?.email || 'Unknown user';
+
+const getAvatarUrl = (person) => (
+  person?.avatar_url || person?.avatarUrl || person?.picture || ''
+);
+
+const getInitial = (person) => {
+  const name = person?.name?.trim();
+  const email = person?.email?.trim();
+
+  if (name) return name.charAt(0).toUpperCase();
+  if (email) return email.charAt(0).toUpperCase();
+  return '?';
+};
+
+const renderAvatar = (person, className, presenceColor) => {
+  const avatarUrl = getAvatarUrl(person);
+  const liveClass = presenceColor ? 'collab-avatar--live' : '';
+  const imageClass = avatarUrl ? 'collab-avatar--image' : '';
+
+  return (
+    <div
+      className={`${className} ${liveClass} ${imageClass}`}
+      style={presenceColor ? { '--presence-color': presenceColor } : undefined}
+      aria-hidden="true"
+    >
+      {avatarUrl ? (
+        <img src={avatarUrl} alt="" />
+      ) : (
+        getInitial(person)
+      )}
+    </div>
+  );
+};
+
+const CollaboratorsPanel = ({ projectId, liveEditors = [] }) => {
   const [activeTab, setActiveTab] = useState('share');
   const [links, setLinks] = useState([]);
   const [collaborators, setCollaborators] = useState([]);
@@ -101,12 +144,60 @@ const CollaboratorsPanel = ({ projectId }) => {
     }
   };
 
-  // Avatar initial: prefer name, fall back to email
-  const getInitial = (collab) => {
-    if (collab.name?.trim()) return collab.name.trim().charAt(0).toUpperCase();
-    if (collab.email) return collab.email.charAt(0).toUpperCase();
-    return '?';
-  };
+  const collaboratorsByKey = useMemo(() => {
+    const next = new Map();
+
+    collaborators.forEach((collab) => {
+      getPersonKeys(collab).forEach((key) => next.set(key, collab));
+    });
+
+    return next;
+  }, [collaborators]);
+
+  const liveEditorRows = useMemo(() => {
+    const rowsByUser = new Map();
+
+    liveEditors.forEach((editor) => {
+      const awarenessUser = editor.user;
+      const userKeys = getPersonKeys(awarenessUser);
+      const primaryKey = userKeys[0] || String(editor.clientId);
+      if (rowsByUser.has(primaryKey)) return;
+
+      const matchingCollaborator = userKeys
+        .map((key) => collaboratorsByKey.get(key))
+        .find(Boolean);
+
+      rowsByUser.set(primaryKey, {
+        ...matchingCollaborator,
+        ...awarenessUser,
+        user_id: matchingCollaborator?.user_id || awarenessUser?.id || primaryKey,
+        name: awarenessUser?.name || matchingCollaborator?.name,
+        email: awarenessUser?.email || matchingCollaborator?.email,
+        avatar_url: awarenessUser?.avatar_url || matchingCollaborator?.avatar_url,
+        color: awarenessUser?.color,
+      });
+    });
+
+    return Array.from(rowsByUser.values()).sort((a, b) => (
+      getDisplayName(a).localeCompare(getDisplayName(b))
+    ));
+  }, [collaboratorsByKey, liveEditors]);
+
+  const liveEditorsByKey = useMemo(() => {
+    const next = new Map();
+
+    liveEditorRows.forEach((editor) => {
+      getPersonKeys(editor).forEach((key) => next.set(key, editor));
+    });
+
+    return next;
+  }, [liveEditorRows]);
+
+  const getLiveEditorForCollaborator = (collab) => (
+    getPersonKeys(collab)
+      .map((key) => liveEditorsByKey.get(key))
+      .find(Boolean)
+  );
 
   return (
     <div className="collaborators-panel">
@@ -214,6 +305,27 @@ const CollaboratorsPanel = ({ projectId }) => {
       {/* Members Tab */}
       {activeTab === 'members' && (
         <div className="collab-tab-content">
+          <div className="collab-section collab-live-section">
+            <h3 className="collab-section-title">Currently editing</h3>
+            {liveEditorRows.length === 0 ? (
+              <p className="collab-empty collab-empty-compact">No other editors connected.</p>
+            ) : (
+              <div className="collab-live-list">
+                {liveEditorRows.map((editor) => (
+                  <div
+                    key={editor.user_id || editor.id || editor.email}
+                    className="collab-live-editor"
+                    style={editor.color ? { '--presence-color': editor.color } : undefined}
+                    title={getDisplayName(editor)}
+                  >
+                    {renderAvatar(editor, 'collab-live-avatar', editor.color)}
+                    <p className="collab-live-name">{getDisplayName(editor)}</p>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
           <div className="collab-section">
             <h3 className="collab-section-title">Project Members</h3>
             {loading ? (
@@ -222,36 +334,44 @@ const CollaboratorsPanel = ({ projectId }) => {
               <p className="collab-empty">No collaborators yet. Share a link to invite people.</p>
             ) : (
               <div className="collab-members-list">
-                {collaborators.map((collab) => (
-                  <div key={collab.user_id} className="collab-member-item">
-                    <div className="collab-member-avatar">
-                      {getInitial(collab)}
+                {collaborators.map((collab) => {
+                  const liveEditor = getLiveEditorForCollaborator(collab);
+                  const avatarSource = liveEditor ? {
+                    ...collab,
+                    avatar_url: collab.avatar_url || liveEditor.avatar_url,
+                    avatarUrl: collab.avatarUrl || liveEditor.avatarUrl,
+                    picture: collab.picture || liveEditor.picture,
+                  } : collab;
+
+                  return (
+                    <div key={collab.user_id} className="collab-member-item">
+                      {renderAvatar(avatarSource, 'collab-member-avatar', liveEditor?.color)}
+                      <div className="collab-member-info">
+                        {/* Name on top, email below */}
+                        <p className="collab-member-name">{getDisplayName(collab)}</p>
+                        {collab.name && (
+                          <p className="collab-member-email">{collab.email}</p>
+                        )}
+                        <p className="collab-member-meta">
+                          {/* role from API: "editor" | "viewer" */}
+                          <span className={`collab-member-access collab-member-access--${collab.role}`}>
+                            {collab.role}
+                          </span>
+                          <span className="collab-member-joined">
+                            {new Date(collab.invited_at).toLocaleDateString()}
+                          </span>
+                        </p>
+                      </div>
+                      <button
+                        onClick={() => handleRemoveCollaborator(collab.user_id)}
+                        className="collab-btn collab-btn-danger collab-btn-remove"
+                        title="Remove collaborator"
+                      >
+                        ✕
+                      </button>
                     </div>
-                    <div className="collab-member-info">
-                      {/* Name on top, email below */}
-                      <p className="collab-member-name">{collab.name || collab.email}</p>
-                      {collab.name && (
-                        <p className="collab-member-email">{collab.email}</p>
-                      )}
-                      <p className="collab-member-meta">
-                        {/* role from API: "editor" | "viewer" */}
-                        <span className={`collab-member-access collab-member-access--${collab.role}`}>
-                          {collab.role}
-                        </span>
-                        <span className="collab-member-joined">
-                          {new Date(collab.invited_at).toLocaleDateString()}
-                        </span>
-                      </p>
-                    </div>
-                    <button
-                      onClick={() => handleRemoveCollaborator(collab.user_id)}
-                      className="collab-btn collab-btn-danger collab-btn-remove"
-                      title="Remove collaborator"
-                    >
-                      ✕
-                    </button>
-                  </div>
-                ))}
+                  );
+                })}
               </div>
             )}
           </div>

--- a/frontend/src/hooks/useCollabSessions.js
+++ b/frontend/src/hooks/useCollabSessions.js
@@ -11,7 +11,7 @@ import { createCollabSession } from '../api/session';
  *   - Binding a session to a Monaco editor instance
  *   - Tracking per-file connection status for UI indicators
  */
-export function useCollabSessions({ projectId, getToken }) {
+export function useCollabSessions({ projectId, getToken, user = null }) {
   // Map of fileId -> session object from createCollabSession().
   // Ref (not state) because mutations don't need re-renders.
   const collabSessions = useRef({});
@@ -43,13 +43,14 @@ export function useCollabSessions({ projectId, getToken }) {
       fileId: file.id,
       projectId,
       token,
+      user,
       onStatus: (status) => {
         setCollabStatus((prev) => ({ ...prev, [file.id]: status }));
       },
     });
 
     collabSessions.current[file.id] = session;
-  }, [projectId, getToken]);
+  }, [projectId, getToken, user]);
 
   const closeCollabSession = useCallback((fileId) => {
     const session = collabSessions.current[fileId];

--- a/frontend/src/hooks/useCollabSessions.js
+++ b/frontend/src/hooks/useCollabSessions.js
@@ -23,6 +23,9 @@ export function useCollabSessions({ projectId, getToken, user = null }) {
   // fileId statuses: 'connecting' | 'connected' | 'disconnected'
   const [collabStatus, setCollabStatus] = useState({});
 
+  // fileId -> awareness users for currently open collaborative sessions
+  const [liveEditorsByFile, setLiveEditorsByFile] = useState({});
+
   // Track which files have a live Monaco binding to avoid double-binding
   const boundFiles = useRef(new Set());
 
@@ -46,6 +49,16 @@ export function useCollabSessions({ projectId, getToken, user = null }) {
       user,
       onStatus: (status) => {
         setCollabStatus((prev) => ({ ...prev, [file.id]: status }));
+        if (status !== 'connected') {
+          setLiveEditorsByFile((prev) => ({ ...prev, [file.id]: [] }));
+          return;
+        }
+
+        const users = collabSessions.current[file.id]?.getAwarenessUsers?.() || [];
+        setLiveEditorsByFile((prev) => ({ ...prev, [file.id]: users }));
+      },
+      onAwarenessChange: (users) => {
+        setLiveEditorsByFile((prev) => ({ ...prev, [file.id]: users }));
       },
     });
 
@@ -62,6 +75,12 @@ export function useCollabSessions({ projectId, getToken, user = null }) {
     delete collabSessions.current[fileId];
 
     setCollabStatus((prev) => {
+      const next = { ...prev };
+      delete next[fileId];
+      return next;
+    });
+
+    setLiveEditorsByFile((prev) => {
       const next = { ...prev };
       delete next[fileId];
       return next;
@@ -109,6 +128,7 @@ const bindActiveSession = useCallback((editor, activeTabId, isCollab, _attempt =
   return {
     collabSessions,   // ref — read .current[fileId] to get a session
     collabStatus,     // state — fileId to status string
+    liveEditorsByFile,
     openCollabSession,
     closeCollabSession,
     bindActiveSession,

--- a/frontend/src/views/EditorView.css
+++ b/frontend/src/views/EditorView.css
@@ -498,6 +498,14 @@
 .collab-connected .collab-dot {
   animation: pulse 2s ease-in-out infinite;
 }
+
+.yRemoteSelection {
+  background-color: rgba(31, 128, 221, 0.18);
+}
+
+.yRemoteSelectionHead {
+  border-left: 2px solid #1f80dd;
+}
  
 @media (prefers-color-scheme: dark) {
   .collab-indicator.collab-connected    { background: rgba(76, 175, 80, 0.08);  }

--- a/frontend/src/views/EditorView.jsx
+++ b/frontend/src/views/EditorView.jsx
@@ -55,7 +55,7 @@ const isImageType = (fileType) => IMAGE_TYPES.has(fileType?.toLowerCase());
  */
 const EditorView = () => {
   const { projectId } = useParams();
-  const { getToken } = useAuth();
+  const { getToken, user } = useAuth();
 
   // Project/loading state 
   const [isCollab, setIsCollab] = useState(false);
@@ -103,7 +103,7 @@ const EditorView = () => {
     openCollabSession,
     closeCollabSession,
     bindActiveSession,
-  } = useCollabSessions({ projectId, getToken });
+  } = useCollabSessions({ projectId, getToken, user });
 
   // useFileManager is declared first so clearFileContent is available
   const {

--- a/frontend/src/views/EditorView.jsx
+++ b/frontend/src/views/EditorView.jsx
@@ -100,6 +100,7 @@ const EditorView = () => {
   const {
     collabSessions,
     collabStatus,
+    liveEditorsByFile,
     openCollabSession,
     closeCollabSession,
     bindActiveSession,
@@ -240,6 +241,10 @@ const EditorView = () => {
   const activeLanguage     = activeTab ? getLanguage(activeTab.file_type) : 'latex';
   const isActiveFileDirty  = !isActiveCollab && !!activeTabId && unsavedFiles.has(activeTabId);
   const imageUrl           = isActiveImage ? fileContents[activeTabId] : null;
+  const activeLiveEditors  =
+    activeTabId && activeCollabStatus === 'connected'
+      ? (liveEditorsByFile[activeTabId] || []).filter((editor) => !editor.isLocal)
+      : [];
 
   // Handle loading/error states
   if (loading) return <div className="editor-loading"><p>Loading project…</p></div>;
@@ -275,7 +280,7 @@ const EditorView = () => {
         className="side-panel"
         style={{ display: sidebarOpen && sidebarPanel === 'collaborators' ? 'flex' : 'none' }}
       >
-        <CollaboratorsPanel projectId={projectId} />
+        <CollaboratorsPanel projectId={projectId} liveEditors={activeLiveEditors} />
       </div>
 
       {/* Main editor column — or a full-area main panel if one is active */}


### PR DESCRIPTION
# feat/display-editor-awareness

## Summary
- This branch packages 3 local commits across `collab-service` and `frontend`.
- It includes: show live collaborators with cursor-matched presence; add collaborative editor awareness; cache awareness state for joining clients.
- File-level impact: 7 updated.
- Implementation context: Add a compact currently editing section above the existing members list in the collaborators panel. Connected collaborators now use the same awareness color for their avatar ring and Monaco remote cursor styling, making it easier to identify whose cursor is whose. Create a Yjs Awareness instance for each collaborative session and seed it with normalized local user metadata from auth state. Send local awareness updates over the existing WebSocket protocol, apply remote awareness frames from the collab service, and clear local awareness during session teardown.

## Changes
### Commits
- `10757b7` feat(collab-service): cache awareness state for joining clients.
  Context: Track the latest awareness payload for each connected client alongside the document's active client set. When a new client registers, replay cached awareness updates from existing peers so presence state is available immediately instead of waiting for the next local cursor or selection change.
- `456450c` feat(frontend): add collaborative editor awareness.
  Context: Create a Yjs Awareness instance for each collaborative session and seed it with normalized local user metadata from auth state. Send local awareness updates over the existing WebSocket protocol, apply remote awareness frames from the collab service, and clear local awareness during session teardown.
- `3041158` feat(frontend): show live collaborators with cursor-matched presence.
  Context: Add a compact currently editing section above the existing members list in the collaborators panel. Connected collaborators now use the same awareness color for their avatar ring and Monaco remote cursor styling, making it easier to identify whose cursor is whose.

### Files
- `collab-service/internal/hub/hub.go` (updated)
- `frontend/src/api/session.js` (updated)
- `frontend/src/components/Editor/CollaboratorsPanel.css` (updated)
- `frontend/src/components/Editor/CollaboratorsPanel.jsx` (updated)
- `frontend/src/hooks/useCollabSessions.js` (updated)
- `frontend/src/views/EditorView.css` (updated)
- `frontend/src/views/EditorView.jsx` (updated)

## Related Issues
- Resolves #13
