### PR TITLE
Feat/dark mode

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,25 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Collaborative Editor</title>
+  <script>
+    (function () {
+      try {
+        var preference = localStorage.getItem('theme_preference') || 'system';
+        var isValid = preference === 'system' || preference === 'light' || preference === 'dark';
+
+        if (!isValid) {
+          preference = 'system';
+        }
+
+        var theme = preference === 'system'
+          ? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+          : preference;
+
+        document.documentElement.dataset.theme = theme;
+        document.documentElement.style.colorScheme = theme;
+      } catch (_) {}
+    })();
+  </script>
 </head>
 <body>
   <div id="root"></div>

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -4,18 +4,109 @@
   padding: 0;
 }
 
-:root {
+:root,
+:root[data-theme="light"] {
+  color-scheme: light;
+
   --primary-color: #2563eb;
   --primary-hover: #1d4ed8;
+  --accent: #2563eb;
+  --accent-hover: #1d4ed8;
+  --accent-dim: #dbeafe;
   --secondary-color: #6b7280;
   --secondary-hover: #4b5563;
+
   --background: #f9fafb;
   --surface: #ffffff;
   --border: #e5e7eb;
+  --border-color: #e0e0e0;
+
   --text-primary: #111827;
   --text-secondary: #6b7280;
+  --text-tertiary: #9ca3af;
+  --text-muted: #6b7280;
+  --text-info: #2563eb;
+
+  --bg-primary: #ffffff;
+  --bg-secondary: #f3f4f6;
+  --bg-tertiary: #e5e7eb;
+  --bg-sidebar: #f9fafb;
+  --bg-tab-bar: #f3f4f6;
+  --bg-hover: #f3f4f6;
+  --bg-active: #e5e7eb;
+  --bg-input: #ffffff;
+  --bg-code: #f3f4f6;
+  --sidebar-bg: #f3f4f6;
+  --hover-bg: rgba(17, 24, 39, 0.06);
+
+  --focus-ring: rgba(37, 99, 235, 0.16);
+  --info-bg: rgba(37, 99, 235, 0.1);
+  --info-bg-strong: rgba(37, 99, 235, 0.16);
+  --success: #16a34a;
+  --success-hover: #15803d;
+  --success-bg: rgba(22, 163, 74, 0.1);
+  --warning: #d97706;
+  --warning-bg: rgba(217, 119, 6, 0.1);
+  --danger: #dc2626;
+  --danger-hover: #b91c1c;
+  --danger-bg: rgba(220, 38, 38, 0.1);
+  --danger-border: #ef4444;
+  --overlay: rgba(0, 0, 0, 0.45);
+
   --shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1);
   --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1);
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+
+  --primary-color: #2563eb;
+  --primary-hover: #1d4ed8;
+  --accent: #60a5fa;
+  --accent-hover: #93c5fd;
+  --accent-dim: #1e3a5f;
+  --secondary-color: #9ca3af;
+  --secondary-hover: #d1d5db;
+
+  --background: #111827;
+  --surface: #1f2937;
+  --border: #374151;
+  --border-color: #3e3e42;
+
+  --text-primary: #f9fafb;
+  --text-secondary: #d1d5db;
+  --text-tertiary: #9ca3af;
+  --text-muted: #9ca3af;
+  --text-info: #60a5fa;
+
+  --bg-primary: #1e1e1e;
+  --bg-secondary: #252526;
+  --bg-tertiary: #2d2d30;
+  --bg-sidebar: #252526;
+  --bg-tab-bar: #252526;
+  --bg-hover: #2d2d30;
+  --bg-active: #37373d;
+  --bg-input: #1f2937;
+  --bg-code: #111827;
+  --sidebar-bg: #252526;
+  --hover-bg: rgba(255, 255, 255, 0.08);
+
+  --focus-ring: rgba(96, 165, 250, 0.2);
+  --info-bg: rgba(96, 165, 250, 0.12);
+  --info-bg-strong: rgba(96, 165, 250, 0.2);
+  --success: #4ade80;
+  --success-hover: #22c55e;
+  --success-bg: rgba(74, 222, 128, 0.12);
+  --warning: #fbbf24;
+  --warning-bg: rgba(251, 191, 36, 0.12);
+  --danger: #f87171;
+  --danger-hover: #ef4444;
+  --danger-bg: rgba(248, 113, 113, 0.12);
+  --danger-border: #ef4444;
+  --overlay: rgba(0, 0, 0, 0.55);
+
+  --shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.35), 0 1px 2px -1px rgba(0, 0, 0, 0.35);
+  --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.45), 0 4px 6px -4px rgba(0, 0, 0, 0.45);
 }
 
 body {
@@ -81,6 +172,8 @@ body {
   padding: 0.5rem 0.75rem;
   border: 1px solid var(--border);
   border-radius: 0.375rem;
+  background: var(--surface);
+  color: var(--text-primary);
   font-size: 0.875rem;
   transition: border-color 0.2s;
 }
@@ -88,7 +181,7 @@ body {
 .form-input:focus {
   outline: none;
   border-color: var(--primary-color);
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+  box-shadow: 0 0 0 3px var(--focus-ring);
 }
 
 .text-muted {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,47 +1,56 @@
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import { AuthProvider } from './contexts/AuthContext';
+import { ThemeProvider } from './contexts/ThemeContext';
 import DashboardView from './views/DashboardView';
 import EditorView from './views/EditorView';
 import LoginView from './views/LoginView';
 import JoinView from './views/JoinView';
 import OAuthCallback from './views/OAuthCallback';
+import SettingsView from './views/SettingsView';
 
 import ProtectedRoute from './components/ProtectedRoute';
 import './App.css';
-
-
 
 function App() {
   return (
     <Router>
       <AuthProvider>
-        <div className="app">
-          <Routes>
-            <Route path="/login" element={<LoginView />} />
-            <Route path="/oauth/callback" element={<OAuthCallback />} />
-            <Route path="/join" element={<JoinView />} />
-            <Route 
-              path="/project/:projectId" 
-              element={
-                <ProtectedRoute>
-                  <EditorView />
-                </ProtectedRoute>
-              } 
-            />
-            <Route 
-              path="/" 
-              element={
-                <ProtectedRoute>
-                  <DashboardView />
-                </ProtectedRoute>
-              } 
-            />
-          </Routes>
-        </div>
+        <ThemeProvider>
+          <div className="app">
+            <Routes>
+              <Route path="/login" element={<LoginView />} />
+              <Route path="/oauth/callback" element={<OAuthCallback />} />
+              <Route path="/join" element={<JoinView />} />
+              <Route
+                path="/settings"
+                element={
+                  <ProtectedRoute>
+                    <SettingsView />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/project/:projectId"
+                element={
+                  <ProtectedRoute>
+                    <EditorView />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/"
+                element={
+                  <ProtectedRoute>
+                    <DashboardView />
+                  </ProtectedRoute>
+                }
+              />
+            </Routes>
+          </div>
+        </ThemeProvider>
       </AuthProvider>
     </Router>
   );
 }
 
- 
 export default App;

--- a/frontend/src/components/Dashboard/JoinProjectModal.css
+++ b/frontend/src/components/Dashboard/JoinProjectModal.css
@@ -44,7 +44,7 @@
 .form-input:focus {
   outline: none;
   border-color: var(--primary-color);
-  box-shadow: 0 0 0 2px rgba(31, 128, 221, 0.1);
+  box-shadow: 0 0 0 2px var(--focus-ring);
 }
 
 .form-input:disabled {
@@ -63,10 +63,10 @@
   align-items: center;
   gap: 0.75rem;
   padding: 0.75rem 1rem;
-  background-color: rgba(211, 47, 47, 0.1);
-  border: 1px solid #d32f2f;
+  background-color: var(--danger-bg);
+  border: 1px solid var(--danger-border);
   border-radius: 0.375rem;
-  color: #d32f2f;
+  color: var(--danger);
   font-size: 0.875rem;
 }
 
@@ -89,21 +89,4 @@
 
 .modal-actions .btn:last-child {
   max-width: none;
-}
-
-/* Dark mode adjustments */
-@media (prefers-color-scheme: dark) {
-  .form-input {
-    background-color: var(--surface);
-    border-color: var(--border);
-  }
-
-  .form-input:focus {
-    border-color: var(--primary-color);
-  }
-
-  .error-message {
-    background-color: rgba(211, 47, 47, 0.15);
-    border-color: #ef5350;
-  }
 }

--- a/frontend/src/components/Dashboard/Modal.css
+++ b/frontend/src/components/Dashboard/Modal.css
@@ -4,7 +4,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background-color: rgba(0, 0, 0, 0.5);
+  background-color: var(--overlay);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/frontend/src/components/Editor/AIPanel/AIPanel.css
+++ b/frontend/src/components/Editor/AIPanel/AIPanel.css
@@ -128,7 +128,7 @@
 }
 
 .ai-chat-delete-btn:hover {
-  color: #f48771;
+  color: var(--danger);
 }
 
 .ai-chat-empty {
@@ -433,11 +433,11 @@
 }
 
 .ai-stop-btn {
-  background: #8b1a1a;
+  background: var(--danger);
 }
 
 .ai-stop-btn:hover:not(:disabled) {
-  background: #b52626 !important;
+  background: var(--danger-hover) !important;
 }
 
 .ai-input-meta {
@@ -466,10 +466,10 @@
 .ai-error-banner {
   margin: 0 14px 8px;
   padding: 7px 10px;
-  background: rgba(244, 135, 113, 0.12);
-  border: 1px solid rgba(244, 135, 113, 0.35);
+  background: var(--danger-bg);
+  border: 1px solid var(--danger-border);
   border-radius: 4px;
-  color: #f48771;
+  color: var(--danger);
   font-size: 12px;
 }
 

--- a/frontend/src/components/Editor/CollaboratorsPanel.css
+++ b/frontend/src/components/Editor/CollaboratorsPanel.css
@@ -31,7 +31,7 @@
 
 .collab-tab:hover {
   color: var(--text-primary, #333);
-  background: rgba(0, 0, 0, 0.02);
+  background: var(--hover-bg);
 }
 
 .collab-tab.active {
@@ -119,7 +119,7 @@
 .collab-select:focus {
   outline: none;
   border-color: var(--text-info, #1f80dd);
-  box-shadow: 0 0 0 2px rgba(31, 128, 221, 0.1);
+  box-shadow: 0 0 0 2px var(--focus-ring);
 }
 
 .collab-select:disabled {
@@ -163,8 +163,8 @@
 }
 
 .collab-btn-primary:hover:not(:disabled) {
-  background: #1565c0;
-  border-color: #1565c0;
+  background: var(--primary-hover);
+  border-color: var(--primary-hover);
 }
 
 .collab-btn-secondary {
@@ -173,12 +173,12 @@
 
 .collab-btn-danger {
   background: none;
-  color: #d32f2f;
-  border-color: #d32f2f;
+  color: var(--danger);
+  border-color: var(--danger);
 }
 
 .collab-btn-danger:hover:not(:disabled) {
-  background: rgba(211, 47, 47, 0.08);
+  background: var(--danger-bg);
 }
 
 /* Remove button: icon-only, compact */
@@ -287,7 +287,7 @@
   min-height: 36px;
   padding: 6px 8px;
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.72), rgba(255, 255, 255, 0.36)),
+    linear-gradient(180deg, var(--surface), transparent),
     var(--bg-sidebar, #f9f9f9);
   border: 0.5px solid var(--border-color, #e0e0e0);
   border-radius: 6px;
@@ -438,14 +438,14 @@
 }
 
 .collab-member-access--editor {
-  background: rgba(31, 128, 221, 0.12);
+  background: var(--info-bg);
   color: var(--text-info, #1f80dd);
 }
 
 /* Role badge — viewer (muted green) */
 .collab-member-access--viewer {
-  background: rgba(56, 142, 60, 0.1);
-  color: #388e3c;
+  background: var(--success-bg);
+  color: var(--success);
 }
 
 .collab-member-joined {
@@ -456,8 +456,8 @@
 /* Error */
 .collab-error {
   padding: 10px 12px;
-  background: rgba(211, 47, 47, 0.08);
-  border: 0.5px solid #d32f2f;
+  background: var(--danger-bg);
+  border: 0.5px solid var(--danger);
   border-radius: 4px;
   margin: 12px 12px 0 12px;
 }
@@ -465,92 +465,5 @@
 .collab-error p {
   margin: 0;
   font-size: 12px;
-  color: #d32f2f;
-}
-
-/* Dark mode */
-@media (prefers-color-scheme: dark) {
-  .collab-tabs {
-    background: var(--bg-sidebar, #252526);
-    border-color: var(--border-color, #3e3e42);
-  }
-
-  .collab-tab {
-    color: var(--text-secondary, #a0a0a0);
-  }
-
-  .collab-tab:hover {
-    background: rgba(255, 255, 255, 0.04);
-  }
-
-  .collab-section {
-    background: var(--bg-primary, #1e1e1e);
-    border-color: var(--border-color, #3e3e42);
-  }
-
-  .collab-select {
-    background: var(--bg-sidebar, #252526);
-    border-color: var(--border-color, #3e3e42);
-    color: var(--text-primary, #e0e0e0);
-  }
-
-  .collab-select:hover {
-    border-color: var(--text-info, #1f80dd);
-  }
-
-  .collab-btn {
-    background: var(--bg-sidebar, #252526);
-    border-color: var(--border-color, #3e3e42);
-    color: var(--text-primary, #e0e0e0);
-  }
-
-  .collab-btn:hover:not(:disabled) {
-    background: var(--bg-primary, #1e1e1e);
-  }
-
-  .collab-link-item {
-    background: var(--bg-sidebar, #252526);
-    border-color: var(--border-color, #3e3e42);
-  }
-
-  .collab-link-item:hover {
-    background: var(--bg-primary, #1e1e1e);
-  }
-
-  .collab-link-url {
-    color: var(--text-primary, #e0e0e0);
-  }
-
-  .collab-live-editor {
-    background:
-      linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.01)),
-      var(--bg-sidebar, #252526);
-    border-color: var(--border-color, #3e3e42);
-  }
-
-  .collab-live-editor:hover {
-    background: var(--bg-primary, #1e1e1e);
-  }
-
-  .collab-avatar--image {
-    background: var(--bg-sidebar, #252526);
-  }
-
-  .collab-member-item {
-    background: var(--bg-sidebar, #252526);
-    border-color: var(--border-color, #3e3e42);
-  }
-
-  .collab-member-item:hover {
-    background: var(--bg-primary, #1e1e1e);
-  }
-
-  .collab-member-email {
-    color: var(--text-secondary, #888);
-  }
-
-  .collab-member-access--viewer {
-    background: rgba(56, 142, 60, 0.15);
-    color: #66bb6a;
-  }
+  color: var(--danger);
 }

--- a/frontend/src/components/Editor/CreateItemModal.css
+++ b/frontend/src/components/Editor/CreateItemModal.css
@@ -5,7 +5,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.3);
+  background: var(--overlay);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -19,7 +19,7 @@
   padding: 24px;
   width: 90%;
   max-width: 400px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-lg);
   animation: slideUp 0.2s ease-out;
 }
 
@@ -59,7 +59,7 @@
   font-size: 13px;
   border: 0.5px solid var(--border-color, #e0e0e0);
   border-radius: 4px;
-  background: var(--bg-primary, #ffffff);
+  background: var(--bg-input);
   color: var(--text-primary, #333);
   font-family: inherit;
   box-sizing: border-box;
@@ -69,21 +69,21 @@
 .form-group input:focus {
   outline: none;
   border-color: var(--text-info, #1f80dd);
-  box-shadow: 0 0 0 2px rgba(31, 128, 221, 0.1);
+  box-shadow: 0 0 0 2px var(--focus-ring);
 }
 
 .form-group input.error {
-  border-color: #d32f2f;
+  border-color: var(--danger);
 }
 
 .form-group input.error:focus {
-  box-shadow: 0 0 0 2px rgba(211, 47, 47, 0.1);
+  box-shadow: 0 0 0 2px var(--danger-bg);
 }
 
 .error-message {
   margin: 6px 0 0 0;
   font-size: 12px;
-  color: #d32f2f;
+  color: var(--danger);
 }
 
 .form-actions {
@@ -117,33 +117,10 @@
 }
 
 .btn-submit:hover {
-  background: #1565c0;
-  border-color: #1565c0;
+  background: var(--primary-hover);
+  border-color: var(--primary-hover);
 }
 
 .btn-submit:active {
   transform: scale(0.98);
-}
-
-/* Dark mode */
-@media (prefers-color-scheme: dark) {
-  .modal-content {
-    background: var(--bg-primary, #1e1e1e);
-    border-color: var(--border-color, #3e3e42);
-  }
-
-  .form-group input {
-    background: var(--bg-sidebar, #252526);
-    border-color: var(--border-color, #3e3e42);
-    color: var(--text-primary, #e0e0e0);
-  }
-
-  .btn-cancel {
-    background: var(--bg-sidebar, #252526);
-    border-color: var(--border-color, #3e3e42);
-  }
-
-  .btn-cancel:hover {
-    background: var(--bg-sidebar, #2d2d30);
-  }
 }

--- a/frontend/src/components/Editor/DeleteConfirmModal.css
+++ b/frontend/src/components/Editor/DeleteConfirmModal.css
@@ -5,7 +5,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.3);
+  background: var(--overlay);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -19,7 +19,7 @@
   padding: 24px;
   width: 90%;
   max-width: 400px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-lg);
   animation: slideUp 0.2s ease-out;
 }
 
@@ -85,33 +85,16 @@
 }
 
 .btn-delete {
-  background: #d32f2f;
+  background: var(--danger);
   color: white;
-  border-color: #d32f2f;
+  border-color: var(--danger);
 }
 
 .btn-delete:hover {
-  background: #b71c1c;
-  border-color: #b71c1c;
+  background: var(--danger-hover);
+  border-color: var(--danger-hover);
 }
 
 .btn-delete:active {
   transform: scale(0.98);
-}
-
-/* Dark mode */
-@media (prefers-color-scheme: dark) {
-  .modal-content {
-    background: var(--bg-primary, #1e1e1e);
-    border-color: var(--border-color, #3e3e42);
-  }
-
-  .btn-cancel {
-    background: var(--bg-sidebar, #252526);
-    border-color: var(--border-color, #3e3e42);
-  }
-
-  .btn-cancel:hover {
-    background: var(--bg-sidebar, #2d2d30);
-  }
 }

--- a/frontend/src/components/Editor/FileTree.css
+++ b/frontend/src/components/Editor/FileTree.css
@@ -43,11 +43,11 @@
 }
 
 .tree-item:hover {
-  background-color: rgba(0, 0, 0, 0.05);
+  background-color: var(--hover-bg);
 }
 
 .file-item.active {
-  background-color: rgba(31, 128, 221, 0.1);
+  background-color: var(--info-bg);
   color: var(--text-info, #1f80dd);
 }
 
@@ -88,7 +88,7 @@
   background: var(--bg-primary, #ffffff);
   border: 0.5px solid var(--border-color, #e0e0e0);
   border-radius: 8px;
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+  box-shadow: var(--shadow-lg);
   z-index: 999;
   min-width: 200px;
   overflow: hidden;
@@ -143,12 +143,12 @@
 
 /* Delete button styling */
 .context-menu-item.delete {
-  color: #d32f2f;
+  color: var(--danger);
 }
 
 .context-menu-item.delete:hover {
-  background-color: rgba(211, 47, 47, 0.08);
-  color: #b71c1c;
+  background-color: var(--danger-bg);
+  color: var(--danger-hover);
 }
 
 /* Divider */
@@ -156,51 +156,4 @@
   height: 0.5px;
   background: var(--border-color, #e0e0e0);
   margin: 6px 0;
-}
-
-/* Dark mode */
-@media (prefers-color-scheme: dark) {
-  .file-tree {
-    background: var(--bg-sidebar, #1e1e1e);
-    border-color: var(--border-color, #333);
-  }
-
-  .tree-header {
-    background: var(--bg-sidebar, #1e1e1e);
-    border-color: var(--border-color, #333);
-  }
-
-  .tree-item:hover {
-    background-color: rgba(255, 255, 255, 0.08);
-  }
-
-  .file-item.active {
-    background-color: rgba(31, 128, 221, 0.15);
-  }
-
-  .context-menu {
-    background: var(--bg-primary, #252526);
-    border-color: var(--border-color, #3e3e42);
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
-  }
-
-  .context-menu-item {
-    color: var(--text-primary, #e0e0e0);
-  }
-
-  .context-menu-item:hover {
-    background-color: var(--bg-sidebar, #2d2d30);
-  }
-
-  .context-menu-item.delete:hover {
-    background-color: rgba(211, 47, 47, 0.15);
-  }
-
-  .context-menu-divider {
-    background: var(--border-color, #3e3e42);
-  }
-
-  .context-menu-item:not(.delete):not(:last-of-type)::after {
-    color: var(--text-tertiary, #606060);
-  }
 }

--- a/frontend/src/components/Editor/LLMPanel/LLMPanel.css
+++ b/frontend/src/components/Editor/LLMPanel/LLMPanel.css
@@ -156,8 +156,8 @@
 }
 
 .llm-icon-btn.danger:hover {
-  background: rgba(239, 68, 68, 0.15);
-  color: #f87171;
+  background: var(--danger-bg);
+  color: var(--danger);
 }
 
 .llm-icon-btn:disabled {
@@ -246,13 +246,13 @@
 }
 
 .llm-save-btn.saved {
-  background: #16a34a;
+  background: var(--success);
 }
 
 .llm-form-error {
   margin: 0;
   font-size: 11px;
-  color: #f87171;
+  color: var(--danger);
 }
 
 .llm-form-hint {

--- a/frontend/src/components/Editor/RenameModal.css
+++ b/frontend/src/components/Editor/RenameModal.css
@@ -5,7 +5,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.3);
+  background: var(--overlay);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -19,7 +19,7 @@
   padding: 24px;
   width: 90%;
   max-width: 400px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-lg);
   animation: slideUp 0.2s ease-out;
 }
 
@@ -59,7 +59,7 @@
   font-size: 13px;
   border: 0.5px solid var(--border-color, #e0e0e0);
   border-radius: 4px;
-  background: var(--bg-primary, #ffffff);
+  background: var(--bg-input);
   color: var(--text-primary, #333);
   font-family: inherit;
   box-sizing: border-box;
@@ -69,21 +69,21 @@
 .form-group input:focus {
   outline: none;
   border-color: var(--text-info, #1f80dd);
-  box-shadow: 0 0 0 2px rgba(31, 128, 221, 0.1);
+  box-shadow: 0 0 0 2px var(--focus-ring);
 }
 
 .form-group input.error {
-  border-color: #d32f2f;
+  border-color: var(--danger);
 }
 
 .form-group input.error:focus {
-  box-shadow: 0 0 0 2px rgba(211, 47, 47, 0.1);
+  box-shadow: 0 0 0 2px var(--danger-bg);
 }
 
 .error-message {
   margin: 6px 0 0 0;
   font-size: 12px;
-  color: #d32f2f;
+  color: var(--danger);
 }
 
 .form-actions {
@@ -117,33 +117,10 @@
 }
 
 .btn-submit:hover {
-  background: #1565c0;
-  border-color: #1565c0;
+  background: var(--primary-hover);
+  border-color: var(--primary-hover);
 }
 
 .btn-submit:active {
   transform: scale(0.98);
-}
-
-/* Dark mode */
-@media (prefers-color-scheme: dark) {
-  .modal-content {
-    background: var(--bg-primary, #1e1e1e);
-    border-color: var(--border-color, #3e3e42);
-  }
-
-  .form-group input {
-    background: var(--bg-sidebar, #252526);
-    border-color: var(--border-color, #3e3e42);
-    color: var(--text-primary, #e0e0e0);
-  }
-
-  .btn-cancel {
-    background: var(--bg-sidebar, #252526);
-    border-color: var(--border-color, #3e3e42);
-  }
-
-  .btn-cancel:hover {
-    background: var(--bg-sidebar, #2d2d30);
-  }
 }

--- a/frontend/src/components/Editor/TabBar.css
+++ b/frontend/src/components/Editor/TabBar.css
@@ -87,7 +87,7 @@
 }
 
 .tab-close:hover {
-  background: rgba(0, 0, 0, 0.08);
+  background: var(--hover-bg);
   color: var(--text-secondary, #666);
 }
 
@@ -95,33 +95,4 @@
   flex: 1;
   height: 40px;
   background: var(--bg-tab-bar, #fafafa);
-}
-
-/* Dark mode support */
-@media (prefers-color-scheme: dark) {
-  .tab-bar {
-    background: var(--bg-tab-bar, #252526);
-    border-color: var(--border-color, #3e3e42);
-  }
-
-  .tab {
-    background: var(--bg-tab-bar, #252526);
-    border-color: var(--border-color, #3e3e42);
-  }
-
-  .tab:hover {
-    background: var(--bg-primary, #1e1e1e);
-  }
-
-  .tab.active {
-    background: var(--bg-primary, #1e1e1e);
-  }
-
-  .tab-close:hover {
-    background: rgba(255, 255, 255, 0.1);
-  }
-
-  .tab-spacer {
-    background: var(--bg-tab-bar, #252526);
-  }
 }

--- a/frontend/src/contexts/ThemeContext.jsx
+++ b/frontend/src/contexts/ThemeContext.jsx
@@ -1,0 +1,86 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+
+export const THEME_KEY = 'theme_preference';
+export const THEME_PREFERENCES = ['system', 'light', 'dark'];
+
+const ThemeContext = createContext(null);
+const validPreferences = new Set(THEME_PREFERENCES);
+
+const canUseDOM = () => typeof window !== 'undefined' && typeof document !== 'undefined';
+
+const getSystemTheme = () => {
+  if (!canUseDOM()) return 'light';
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+};
+
+const resolveTheme = (preference) => (preference === 'system' ? getSystemTheme() : preference);
+
+const getStoredThemePreference = () => {
+  if (!canUseDOM()) return 'system';
+
+  try {
+    const value = window.localStorage.getItem(THEME_KEY);
+    return validPreferences.has(value) ? value : 'system';
+  } catch {
+    return 'system';
+  }
+};
+
+export function ThemeProvider({ children }) {
+  const [themePreference, setThemePreferenceState] = useState(getStoredThemePreference);
+  const [resolvedTheme, setResolvedTheme] = useState(() => resolveTheme(themePreference));
+
+  useEffect(() => {
+    setResolvedTheme(resolveTheme(themePreference));
+  }, [themePreference]);
+
+  useEffect(() => {
+    if (!canUseDOM() || themePreference !== 'system') return undefined;
+
+    const media = window.matchMedia('(prefers-color-scheme: dark)');
+    const handleChange = () => setResolvedTheme(resolveTheme('system'));
+
+    media.addEventListener('change', handleChange);
+    return () => media.removeEventListener('change', handleChange);
+  }, [themePreference]);
+
+  useEffect(() => {
+    if (!canUseDOM()) return;
+
+    document.documentElement.dataset.theme = resolvedTheme;
+    document.documentElement.style.colorScheme = resolvedTheme;
+  }, [resolvedTheme]);
+
+  const setThemePreference = useCallback((nextPreference) => {
+    if (!validPreferences.has(nextPreference)) return;
+
+    try {
+      window.localStorage.setItem(THEME_KEY, nextPreference);
+    } catch {
+      // localStorage may be unavailable in hardened browser contexts.
+    }
+
+    setThemePreferenceState(nextPreference);
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      themePreference,
+      resolvedTheme,
+      setThemePreference,
+    }),
+    [themePreference, resolvedTheme, setThemePreference]
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+
+  return context;
+}

--- a/frontend/src/views/DashboardView.css
+++ b/frontend/src/views/DashboardView.css
@@ -32,9 +32,9 @@
   position: fixed;
   top: 1rem;
   right: 1rem;
-  background: #fee2e2;
-  border: 1px solid #f87171;
-  color: #991b1b;
+  background: var(--danger-bg);
+  border: 1px solid var(--danger-border);
+  color: var(--danger);
   padding: 0.75rem 1.25rem;
   border-radius: 8px;
   cursor: pointer;

--- a/frontend/src/views/EditorView.css
+++ b/frontend/src/views/EditorView.css
@@ -1,27 +1,3 @@
-:root {
-  --bg-primary: #ffffff;
-  --bg-sidebar: #f9f9f9;
-  --bg-tab-bar: #fafafa;
-  --border-color: #e0e0e0;
-  --text-primary: #333333;
-  --text-secondary: #666666;
-  --text-tertiary: #999999;
-  --text-info: #1f80dd;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --bg-primary: #1e1e1e;
-    --bg-sidebar: #252526;
-    --bg-tab-bar: #252526;
-    --border-color: #3e3e42;
-    --text-primary: #e0e0e0;
-    --text-secondary: #a0a0a0;
-    --text-tertiary: #606060;
-    --text-info: #1f80dd;
-  }
-}
-
 .editor-container {
   display: flex;
   position: relative;
@@ -47,7 +23,6 @@
   background: var(--bg-primary);
 }
 
-/* Monaco Editor container - inherits flex layout */
 .editor-content > div {
   flex: 1;
   width: 100%;
@@ -76,10 +51,9 @@
 }
 
 .editor-error {
-  color: #d32f2f;
+  color: var(--danger);
 }
 
-/* Right Sidebar */
 .editor-sidebar-right {
   width: 240px;
   border-left: 0.5px solid var(--border-color);
@@ -134,7 +108,6 @@
   word-break: break-all;
 }
 
-/* Scrollbar styling for sidebars and info panel */
 .file-tree::-webkit-scrollbar,
 .sidebar-content::-webkit-scrollbar {
   width: 8px;
@@ -154,207 +127,6 @@
 .file-tree::-webkit-scrollbar-thumb:hover,
 .sidebar-content::-webkit-scrollbar-thumb:hover {
   background: var(--text-tertiary);
-}
-
-/* Responsive */
-@media (max-width: 1024px) {
-  .editor-sidebar-right {
-    width: 200px;
-  }
-}
-
-@media (max-width: 768px) {
-  .editor-container {
-    flex-direction: column;
-  }
-
-  .file-tree {
-    width: 100%;
-    height: 200px;
-    border-right: none;
-    border-bottom: 0.5px solid var(--border-color);
-  }
-
-  .editor-sidebar-right {
-    display: none;
-  }
-}/* src/views/EditorView.css - Updated for Monaco Editor */
-:root {
-  --bg-primary: #ffffff;
-  --bg-sidebar: #f9f9f9;
-  --bg-tab-bar: #fafafa;
-  --border-color: #e0e0e0;
-  --text-primary: #333333;
-  --text-secondary: #666666;
-  --text-tertiary: #999999;
-  --text-info: #1f80dd;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --bg-primary: #1e1e1e;
-    --bg-sidebar: #252526;
-    --bg-tab-bar: #252526;
-    --border-color: #3e3e42;
-    --text-primary: #e0e0e0;
-    --text-secondary: #a0a0a0;
-    --text-tertiary: #606060;
-    --text-info: #1f80dd;
-  }
-}
-
-.editor-container {
-  display: flex;
-  height: 100vh;
-  background: var(--bg-primary);
-  overflow: hidden;
-}
-
-.editor-main {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  background: var(--bg-primary);
-}
-
-.editor-content {
-  flex: 1;
-  display: flex;
-  overflow: hidden;
-  background: var(--bg-primary);
-}
-
-/* Monaco Editor container - inherits flex layout */
-.editor-content > div {
-  flex: 1;
-  width: 100%;
-}
-
-.editor-empty {
-  flex: 1;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--text-tertiary);
-}
-
-.editor-empty p {
-  font-size: 14px;
-  margin: 0;
-}
-
-.editor-loading,
-.editor-error {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: 100vh;
-  color: var(--text-secondary);
-}
-
-.editor-error {
-  color: #d32f2f;
-}
-
-/* Right Sidebar */
-.editor-sidebar-right {
-  width: 240px;
-  border-left: 0.5px solid var(--border-color);
-  display: flex;
-  flex-direction: column;
-  background: var(--bg-sidebar);
-  font-size: 13px;
-}
-
-.sidebar-header {
-  padding: 12px 16px;
-  border-bottom: 0.5px solid var(--border-color);
-}
-
-.sidebar-header p {
-  margin: 0;
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--text-secondary);
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-}
-
-.sidebar-content {
-  flex: 1;
-  padding: 12px;
-  overflow-y: auto;
-}
-
-.info-card {
-  background: var(--bg-primary);
-  border: 0.5px solid var(--border-color);
-  border-radius: 6px;
-  padding: 12px;
-  margin-bottom: 12px;
-}
-
-.info-label {
-  margin: 0 0 8px 0;
-  font-size: 11px;
-  font-weight: 600;
-  color: var(--text-secondary);
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-}
-
-.info-value {
-  margin: 0;
-  font-size: 13px;
-  color: var(--text-primary);
-  font-family: 'Menlo', 'Monaco', 'Courier New', monospace;
-  word-break: break-all;
-}
-
-/* Scrollbar styling for sidebars and info panel */
-.file-tree::-webkit-scrollbar,
-.sidebar-content::-webkit-scrollbar {
-  width: 8px;
-}
-
-.file-tree::-webkit-scrollbar-track,
-.sidebar-content::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-.file-tree::-webkit-scrollbar-thumb,
-.sidebar-content::-webkit-scrollbar-thumb {
-  background: var(--border-color);
-  border-radius: 4px;
-}
-
-.file-tree::-webkit-scrollbar-thumb:hover,
-.sidebar-content::-webkit-scrollbar-thumb:hover {
-  background: var(--text-tertiary);
-}
-
-/* Responsive */
-@media (max-width: 1024px) {
-  .editor-sidebar-right {
-    width: 200px;
-  }
-}
-
-@media (max-width: 768px) {
-  .editor-container {
-    flex-direction: column;
-  }
-
-  .file-tree {
-    width: 100%;
-    height: 200px;
-    border-right: none;
-    border-bottom: 0.5px solid var(--border-color);
-  }
-
-  .editor-sidebar-right {
-    display: none;
-  }
 }
 
 .save-button {
@@ -368,94 +140,28 @@
   display: flex;
   align-items: center;
 }
- 
+
 .save-button:hover:not(:disabled) {
-  background: rgba(31, 128, 221, 0.1);
+  background: var(--info-bg);
 }
- 
+
 .save-button:disabled {
   opacity: 0.4;
   cursor: not-allowed;
 }
- 
+
 .save-button:active:not(:disabled) {
   transform: scale(0.95);
 }
- 
-/* Unsaved indicator in sidebar */
+
 .unsaved-indicator {
-  color: var(--text-info, #1f80dd);
+  color: var(--text-info);
   margin-left: 4px;
   font-weight: bold;
 }
- 
-/* Save status bar at bottom of editor */
-.save-indicator {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  height: 24px;
-  background: rgba(31, 128, 221, 0.1);
-  border-top: 0.5px solid var(--text-info, #1f80dd);
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 0 12px;
-  font-size: 12px;
-  color: var(--text-info, #1f80dd);
-  z-index: 10;
-}
- 
-.unsaved-dot {
-  font-size: 8px;
-  animation: pulse 1.5s ease-in-out infinite;
-}
- 
-@keyframes pulse {
-  0%, 100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.5;
-  }
-}
- 
-.saving-indicator {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  height: 24px;
-  background: rgba(76, 175, 80, 0.1);
-  border-top: 0.5px solid #4caf50;
-  display: flex;
-  align-items: center;
-  padding: 0 12px;
-  font-size: 12px;
-  color: #4caf50;
-  z-index: 10;
-}
 
-
-/* Dark mode adjustments */
-@media (prefers-color-scheme: dark) {
-  .save-button:hover:not(:disabled) {
-    background: rgba(31, 128, 221, 0.2);
-  }
- 
-  .save-indicator {
-    background: rgba(31, 128, 221, 0.08);
-    border-color: var(--text-info, #1f80dd);
-  }
- 
-  .saving-indicator {
-    background: rgba(76, 175, 80, 0.08);
-    border-color: #4caf50;
-  }
-}
-
-
+.save-indicator,
+.saving-indicator,
 .collab-indicator {
   position: absolute;
   bottom: 0;
@@ -469,48 +175,63 @@
   font-size: 12px;
   z-index: 10;
 }
- 
-/* connected */
+
+.save-indicator {
+  background: var(--info-bg);
+  border-top: 0.5px solid var(--text-info);
+  color: var(--text-info);
+}
+
+.saving-indicator,
 .collab-indicator.collab-connected {
-  background: rgba(76, 175, 80, 0.1);
-  border-top: 0.5px solid #4caf50;
-  color: #4caf50;
+  background: var(--success-bg);
+  border-top: 0.5px solid var(--success);
+  color: var(--success);
 }
- 
-/* connecting (initial / reconnecting) */
-.collab-indicator.collab-connecting {
-  background: rgba(255, 152, 0, 0.1);
-  border-top: 0.5px solid #ff9800;
-  color: #ff9800;
-}
- 
-/* disconnected */
-.collab-indicator.collab-disconnected {
-  background: rgba(244, 67, 54, 0.08);
-  border-top: 0.5px solid #f44336;
-  color: #f44336;
-}
- 
+
+.unsaved-dot,
 .collab-dot {
   font-size: 8px;
 }
- 
+
+.unsaved-dot,
 .collab-connected .collab-dot {
-  animation: pulse 2s ease-in-out infinite;
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0.5;
+  }
+}
+
+.collab-indicator.collab-connecting {
+  background: var(--warning-bg);
+  border-top: 0.5px solid var(--warning);
+  color: var(--warning);
+}
+
+.collab-indicator.collab-disconnected {
+  background: var(--danger-bg);
+  border-top: 0.5px solid var(--danger);
+  color: var(--danger);
+}
+
+.collab-connected .collab-dot {
+  animation-duration: 2s;
 }
 
 .yRemoteSelection {
-  background-color: rgba(31, 128, 221, 0.18);
+  background-color: var(--info-bg-strong);
 }
 
 .yRemoteSelectionHead {
-  border-left: 2px solid #1f80dd;
-}
- 
-@media (prefers-color-scheme: dark) {
-  .collab-indicator.collab-connected    { background: rgba(76, 175, 80, 0.08);  }
-  .collab-indicator.collab-connecting   { background: rgba(255, 152, 0, 0.08); }
-  .collab-indicator.collab-disconnected { background: rgba(244, 67, 54, 0.06); }
+  border-left: 2px solid var(--text-info);
 }
 
 .home-button {
@@ -528,7 +249,7 @@
 }
 
 .home-button:hover {
-  background: rgba(31, 128, 221, 0.08);
+  background: var(--info-bg);
   color: var(--text-info);
 }
 
@@ -539,7 +260,7 @@
   justify-content: center;
   height: 100%;
   gap: 12px;
-  background: var(--bg-secondary, #1e1e1e);
+  background: var(--bg-secondary);
   overflow: auto;
 }
 
@@ -548,12 +269,12 @@
   max-height: calc(100% - 48px);
   object-fit: contain;
   border-radius: 4px;
-  box-shadow: 0 4px 24px rgba(0,0,0,0.4);
+  box-shadow: var(--shadow-lg);
 }
 
 .image-filename {
   font-size: 12px;
-  color: var(--text-secondary, #888);
+  color: var(--text-secondary);
   font-family: 'Menlo', monospace;
 }
 
@@ -571,4 +292,27 @@
   width: 220px;
   min-width: 220px;
   flex-shrink: 0;
+}
+
+@media (max-width: 1024px) {
+  .editor-sidebar-right {
+    width: 200px;
+  }
+}
+
+@media (max-width: 768px) {
+  .editor-container {
+    flex-direction: column;
+  }
+
+  .file-tree {
+    width: 100%;
+    height: 200px;
+    border-right: none;
+    border-bottom: 0.5px solid var(--border-color);
+  }
+
+  .editor-sidebar-right {
+    display: none;
+  }
 }

--- a/frontend/src/views/EditorView.jsx
+++ b/frontend/src/views/EditorView.jsx
@@ -7,6 +7,7 @@ import darkTheme from '../monaco/themes/monokai.json';
 import lightTheme from '../monaco/themes/github-light.json';
 
 import { useAuth } from '../contexts/AuthContext';
+import { useTheme } from '../contexts/ThemeContext';
 import { useCollabSessions } from '../hooks/useCollabSessions';
 import { useTabManager } from '../hooks/useTabManager';
 import { useFileManager } from '../hooks/useFileManager';
@@ -56,6 +57,8 @@ const isImageType = (fileType) => IMAGE_TYPES.has(fileType?.toLowerCase());
 const EditorView = () => {
   const { projectId } = useParams();
   const { getToken, user } = useAuth();
+  const { resolvedTheme } = useTheme();
+  const isDarkMode = resolvedTheme === 'dark';
 
   // Project/loading state 
   const [isCollab, setIsCollab] = useState(false);
@@ -64,24 +67,13 @@ const EditorView = () => {
   // User role
   const [userRole, setUserRole] = useState(null);
 
-  // Dark mode
-  const [isDarkMode, setIsDarkMode] = useState(
-    window.matchMedia('(prefers-color-scheme: dark)').matches
-  );
-  useEffect(() => {
-    const mq = window.matchMedia('(prefers-color-scheme: dark)');
-    const handler = (e) => setIsDarkMode(e.matches);
-    mq.addEventListener('change', handler);
-    return () => mq.removeEventListener('change', handler);
-  }, []);
-
   // Activity bar
   const [sidebarPanel, setSidebarPanel] = useState('files'); // Which panel is shown
   const [sidebarOpen, setSidebarOpen] = useState(true);
   const [mainPanel, setMainPanel] = useState(null); // Show editor when null
 
   // Toggle/switch sidebar panels
-    const handlePanelToggle = useCallback((panelId, type) => {
+  const handlePanelToggle = useCallback((panelId, type) => {
     if (type === 'sidebar') {
       setSidebarOpen((open) => {
         if (sidebarPanel === panelId) return !open; // Toggle if same panel

--- a/frontend/src/views/LoginView.css
+++ b/frontend/src/views/LoginView.css
@@ -32,7 +32,7 @@
 .login-card {
   background-color: var(--surface);
   border-radius: 0.75rem;
-  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+  box-shadow: var(--shadow-lg);
   padding: 2rem;
 }
 
@@ -90,10 +90,10 @@
 
 .error-message {
   padding: 0.75rem 1rem;
-  background-color: #fee2e2;
-  border: 1px solid #fca5a5;
+  background-color: var(--danger-bg);
+  border: 1px solid var(--danger-border);
   border-radius: 0.375rem;
-  color: #991b1b;
+  color: var(--danger);
   font-size: 0.875rem;
   margin-bottom: 1rem;
 }

--- a/frontend/src/views/SettingsView.css
+++ b/frontend/src/views/SettingsView.css
@@ -1,0 +1,108 @@
+.settings-view {
+  min-height: 100vh;
+  background: var(--background);
+  color: var(--text-primary);
+}
+
+.settings-header {
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  display: flex;
+  justify-content: flex-start;
+  padding: 1rem 2rem;
+}
+
+.settings-panel {
+  max-width: 920px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.settings-title-group {
+  margin-bottom: 1.5rem;
+}
+
+.settings-title-group h1 {
+  font-size: 1.75rem;
+  line-height: 1.2;
+  margin: 0;
+}
+
+.settings-row {
+  align-items: center;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: var(--shadow);
+  display: flex;
+  gap: 1.5rem;
+  justify-content: space-between;
+  padding: 1.25rem;
+}
+
+.settings-row-copy h2 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.theme-segmented-control {
+  background: var(--background);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  display: inline-flex;
+  gap: 0.25rem;
+  padding: 0.25rem;
+}
+
+.theme-segment {
+  align-items: center;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  display: inline-flex;
+  font: inherit;
+  font-size: 0.875rem;
+  font-weight: 500;
+  gap: 0.5rem;
+  min-height: 2.25rem;
+  padding: 0.45rem 0.75rem;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.theme-segment:hover {
+  background: var(--surface);
+  color: var(--text-primary);
+}
+
+.theme-segment.active {
+  background: var(--surface);
+  border-color: var(--border);
+  box-shadow: var(--shadow);
+  color: var(--primary-color);
+}
+
+@media (max-width: 640px) {
+  .settings-header,
+  .settings-panel {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+
+  .settings-row {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .theme-segmented-control {
+    width: 100%;
+  }
+
+  .theme-segment {
+    flex: 1;
+    justify-content: center;
+  }
+}

--- a/frontend/src/views/SettingsView.jsx
+++ b/frontend/src/views/SettingsView.jsx
@@ -1,0 +1,69 @@
+import { FiMonitor, FiMoon, FiSun } from 'react-icons/fi';
+import { useNavigate } from 'react-router-dom';
+import { THEME_PREFERENCES, useTheme } from '../contexts/ThemeContext';
+import './SettingsView.css';
+
+const THEME_OPTIONS = {
+  system: {
+    label: 'System',
+    Icon: FiMonitor,
+  },
+  light: {
+    label: 'Light',
+    Icon: FiSun,
+  },
+  dark: {
+    label: 'Dark',
+    Icon: FiMoon,
+  },
+};
+
+function SettingsView() {
+  const navigate = useNavigate();
+  const { themePreference, setThemePreference } = useTheme();
+
+  return (
+    <main className="settings-view">
+      <header className="settings-header">
+        <button type="button" className="btn btn-secondary" onClick={() => navigate('/')}>
+          Dashboard
+        </button>
+      </header>
+
+      <section className="settings-panel">
+        <div className="settings-title-group">
+          <h1>Settings</h1>
+        </div>
+
+        <div className="settings-row">
+          <div className="settings-row-copy">
+            <h2>Appearance</h2>
+          </div>
+
+          <div className="theme-segmented-control" role="radiogroup" aria-label="Appearance">
+            {THEME_PREFERENCES.map((preference) => {
+              const { label, Icon } = THEME_OPTIONS[preference];
+              const isActive = themePreference === preference;
+
+              return (
+                <button
+                  key={preference}
+                  type="button"
+                  className={`theme-segment ${isActive ? 'active' : ''}`}
+                  onClick={() => setThemePreference(preference)}
+                  role="radio"
+                  aria-checked={isActive}
+                >
+                  <Icon aria-hidden="true" />
+                  <span>{label}</span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}
+
+export default SettingsView;


### PR DESCRIPTION
# feat/dark-mode

## Summary
- This branch packages 4 local commits across `frontend`.
- It includes: tokenize legacy panel colors; use shared tokens for editor chrome; add appearance settings page; add persistent theme foundation.
- File-level impact: 3 added and 17 updated.
- Implementation context: Replace hard-coded overlay, focus, error, success, and warning colors in dashboard, login, collaborator, LLM, and assistant panel styles with the shared theme variables. Remove the remaining component-level dark-mode media override from the collaborator panel so system preference is handled only by the theme provider. This narrows legacy color usage to brand-like or fallback values while making the obvious UI states theme-aware. Read the resolved app theme in EditorView so Monaco uses the same light or dark mode as the rest of the UI. Remove duplicated editor root variables and replace editor status, tab, file tree, context menu, and modal styling with shared semantic tokens. This keeps explicit user theme selection from being overridden by component-level prefers-color-scheme rules.

## Changes
### Commits
- `89f26d0` feat(frontend): add persistent theme foundation.
  Context: Add a theme context that stores the user's appearance preference in localStorage and resolves system mode from the browser media query. Apply the resolved theme to the document root with data-theme and color-scheme so CSS tokens can switch globally. Add a small pre-mount script to set the same root theme before React loads and avoid an initial theme flash.
- `c8610da` feat(frontend): add appearance settings page.
  Context: Register a protected settings route and add a compact appearance control for System, Light, and Dark preferences. The settings screen uses the shared theme context so changes apply immediately and persist in the current browser. Reuse existing app button styling with a small settings-specific layout stylesheet.
- `0bea2ff` refactor(frontend): use shared tokens for editor chrome.
  Context: Read the resolved app theme in EditorView so Monaco uses the same light or dark mode as the rest of the UI. Remove duplicated editor root variables and replace editor status, tab, file tree, context menu, and modal styling with shared semantic tokens. This keeps explicit user theme selection from being overridden by component-level prefers-color-scheme rules.
- `db10261` refactor(frontend): tokenize legacy panel colors.
  Context: Replace hard-coded overlay, focus, error, success, and warning colors in dashboard, login, collaborator, LLM, and assistant panel styles with the shared theme variables. Remove the remaining component-level dark-mode media override from the collaborator panel so system preference is handled only by the theme provider. This narrows legacy color usage to brand-like or fallback values while making the obvious UI states theme-aware.

### Files
- `frontend/index.html` (updated)
- `frontend/src/App.css` (updated)
- `frontend/src/App.jsx` (updated)
- `frontend/src/components/Dashboard/JoinProjectModal.css` (updated)
- `frontend/src/components/Dashboard/Modal.css` (updated)
- `frontend/src/components/Editor/AIPanel/AIPanel.css` (updated)
- `frontend/src/components/Editor/CollaboratorsPanel.css` (updated)
- `frontend/src/components/Editor/CreateItemModal.css` (updated)
- `frontend/src/components/Editor/DeleteConfirmModal.css` (updated)
- `frontend/src/components/Editor/FileTree.css` (updated)
- `frontend/src/components/Editor/LLMPanel/LLMPanel.css` (updated)
- `frontend/src/components/Editor/RenameModal.css` (updated)
- `frontend/src/components/Editor/TabBar.css` (updated)
- `frontend/src/contexts/ThemeContext.jsx` (added)
- `frontend/src/views/DashboardView.css` (updated)
- `frontend/src/views/EditorView.css` (updated)
- `frontend/src/views/EditorView.jsx` (updated)
- `frontend/src/views/LoginView.css` (updated)
- `frontend/src/views/SettingsView.css` (added)
- `frontend/src/views/SettingsView.jsx` (added)

## Related Issues
- Resolves #24
