### PR TITLE
Build/gateway prod image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.agent
+**/node_modules
+**/dist
+**/target
+**/__pycache__
+**/.pytest_cache
+**/.venv
+**/tmp
+*.log
+.env
+.env.*

--- a/README.md
+++ b/README.md
@@ -65,14 +65,9 @@ make dev-reset                # also remove dev volumes
 
 ### Production
 
-Production mode uses `docker-compose.yml` plus `docker-compose.prod.yml`. It builds production service images, serves `frontend/dist` through nginx, and starts the Cloudflare tunnel sidecar.
+Production mode uses `docker-compose.yml` plus `docker-compose.prod.yml`. It builds production service images, packages the Vite frontend into the nginx gateway image, and starts the Cloudflare tunnel sidecar.
 
 ```sh
-cd frontend
-npm install
-npm run build
-cd ..
-
 make prod-build
 make prod-up
 ```

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,9 +1,14 @@
 services:
   nginx:
+    image: sync-tex-nginx:prod
+    build:
+      context: .
+      dockerfile: nginx/Dockerfile
+      args:
+        GIT_SHA: ${GIT_SHA:-unknown}
+        BUILD_DATE: ${BUILD_DATE:-unknown}
     restart: unless-stopped
-    volumes:
-      - ./nginx/conf.d/frontend.conf:/etc/nginx/conf.d/frontend.conf:ro
-      - ./frontend/dist:/usr/share/nginx/html:ro
+    volumes: !reset []
 
   postgres-users:
     restart: unless-stopped

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,47 @@
+# syntax=docker/dockerfile:1
+
+# Build the Vite frontend in a disposable Node stage. The final nginx image
+# only receives the compiled static files.
+FROM node:20-bookworm-slim@sha256:2cf067cfed83d5ea958367df9f966191a942351a2df77d6f0193e162b5febfc0 AS builder
+WORKDIR /app
+
+# Copy dependency manifests first so Docker can reuse the npm install layer
+# when only frontend source files change.
+COPY frontend/package*.json ./
+RUN --mount=type=cache,target=/root/.npm npm ci
+
+COPY frontend ./
+RUN npm run build
+
+# Runtime gateway image: nginx config plus the compiled frontend assets. No
+# frontend source, node_modules, or build tooling is copied into this stage.
+FROM nginx:1.27-alpine3.21-slim@sha256:b947b2630c97622793113555e13332eec85bdc7a0ac6ab697159af78942bb856 AS runtime
+WORKDIR /usr/share/nginx/html
+
+# Build metadata is optional and safe to omit; Compose defaults these args to
+# "unknown" when they are not supplied by the deployment environment.
+ARG GIT_SHA=unknown
+ARG BUILD_DATE=unknown
+LABEL org.opencontainers.image.title="sync-tex-nginx" \
+      org.opencontainers.image.description="SyncTeX nginx gateway with compiled frontend assets" \
+      org.opencontainers.image.revision="${GIT_SHA}" \
+      org.opencontainers.image.created="${BUILD_DATE}" \
+      org.opencontainers.image.source="sync-tex"
+
+COPY nginx/nginx.conf /etc/nginx/nginx.conf
+COPY nginx/conf.d/default.conf /etc/nginx/conf.d/default.conf
+COPY nginx/conf.d/frontend.conf /etc/nginx/conf.d/frontend.conf
+
+# Vite writes index.html and hashed assets under /app/dist.
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+EXPOSE 80
+
+# Validate the same gateway health route exposed by nginx/conf.d/default.conf.
+HEALTHCHECK --interval=15s --timeout=5s --start-period=10s --retries=3 \
+    CMD wget -q -O - http://127.0.0.1/health || exit 1
+
+STOPSIGNAL SIGTERM
+
+# Keep nginx in the foreground so Docker can supervise the process.
+CMD ["nginx", "-g", "daemon off;"]

--- a/nginx/conf.d/frontend.conf
+++ b/nginx/conf.d/frontend.conf
@@ -1,4 +1,11 @@
+location /assets/ {
+    root /usr/share/nginx/html;
+    try_files $uri =404;
+    add_header Cache-Control "public, max-age=31536000, immutable";
+}
+
 location / {
     root /usr/share/nginx/html;
     try_files $uri $uri/ /index.html;
+    add_header Cache-Control "no-cache";
 }


### PR DESCRIPTION
# build/gateway-prod-image

## Summary
- Packages the production Vite frontend into a self-contained nginx gateway image built by `docker-compose.prod.yml`.
- Replaces production bind mounts for `frontend/dist` and nginx frontend config with image-baked assets and config.
- Adds browser cache handling for hashed frontend assets while keeping the SPA entrypoint uncached.
- Updates the production README flow so operators can use `make prod-build` and `make prod-up` without manually building the frontend first.

## Changes
### Commits
- `9096556` feat(api-gateway): bake frontend assets into the production nginx image.
  Context: Adds a multi-stage `nginx/Dockerfile` that runs `npm ci` and `npm run build` for the frontend, then copies the compiled `dist` output into the runtime nginx image. The production Compose override now builds `sync-tex-nginx:prod`, passes optional build metadata, and resets the development gateway bind mounts.
- `80d493e` docs(readme): update production startup instructions.
  Context: Removes the manual `frontend` install/build instructions from the production runbook and documents that the nginx gateway image packages the compiled Vite app during `make prod-build`.

### Files
- `.dockerignore` (added)
  Excludes local Git metadata, dependency directories, build outputs, Python caches, logs, and env files from Docker build contexts.
- `README.md` (updated)
  Aligns production startup instructions with the image-based frontend build.
- `docker-compose.prod.yml` (updated)
  Builds and runs the production nginx gateway image and clears development bind mounts.
- `nginx/Dockerfile` (added)
  Builds frontend assets in a Node stage and serves them from the nginx runtime stage with gateway configuration included.
- `nginx/conf.d/frontend.conf` (updated)
  Adds long-lived immutable caching for `/assets/` and no-cache handling for the SPA fallback.

## Related Issues
- Resolves #46
