### PR TITLE
Docs/agent test generation skills

### DIFF
--- a/.agent/skills/implement-integration-tests/SKILL.md
+++ b/.agent/skills/implement-integration-tests/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: implement-integration-tests
+description: Implement one pytest integration test file for a SyncTeX REST backend route group from a service TEST_PLAN.md. Use when the harness already exists and the user provides or identifies one plan route group to convert into black-box tests using that service conftest.py and helpers.
+---
+
+# Implement Integration Tests
+
+Implement one SyncTeX REST backend route group from `tests/<service>/TEST_PLAN.md` as one pytest file. The plan is the source of truth. Write only the route-group test file.
+
+## Required Inputs
+
+Before writing code, identify:
+
+- Target service directory, such as `projects-service`.
+- Assigned route group section from `tests/<service>/TEST_PLAN.md`, such as `Project Item`.
+- Existing harness files under `tests/<service>/`.
+
+If the service or route group is missing and cannot be inferred, ask for it before inspecting files.
+
+## Read Before Writing
+
+Read these files before producing any test code:
+
+1. The assigned route group section from `tests/<service>/TEST_PLAN.md`.
+2. `tests/<service>/conftest.py`, to identify fixture names, scopes, and return shapes.
+3. Every file under `tests/<service>/helpers/`, to identify exact auth, DB, MinIO, and fake helper APIs.
+4. Existing `tests/<service>/test_*.py` files, to match local patterns and avoid collisions.
+
+Do not inspect service source files to re-derive behavior. If the plan and source behavior appear to disagree from already-provided context, implement the plan and leave:
+
+```python
+# TODO: verify - plan says 404 but source may differ
+```
+
+## Output File
+
+Write exactly one file for the route group:
+
+```text
+tests/<service>/test_<resource>_<group>.py
+```
+
+Use the repository's existing test naming pattern if one already exists. Otherwise use:
+
+- Collection routes, such as `POST /projects` and `GET /projects`: `test_projects_collection.py`.
+- Item routes, such as `GET /projects/:id`, `PATCH /projects/:id`, and `DELETE /projects/:id`: `test_projects_item.py`.
+- Named flows, such as `POST /invites` and `POST /invites/:token/accept`: `test_invites_flow.py`.
+
+## File Structure
+
+Every generated test file must use this structure, in this order:
+
+```python
+# tests/<service>/test_<resource>_<group>.py
+# Route group: <exact group name from TEST_PLAN.md>
+# Routes covered: METHOD /path, METHOD /path
+
+import pytest
+import requests
+
+# Import helpers by name only when used. Never use wildcard imports.
+from helpers.auth import mint_token
+from helpers.db import query_row
+from helpers.minio import object_exists
+from helpers.fakes import set_fake_response
+
+
+# -- <METHOD> <path> ---------------------------------------------------------
+
+def test_<method>_<resource>_<case>(base_url, unique_user):
+    ...
+
+
+# -- Coverage Gaps -----------------------------------------------------------
+
+# Coverage Gaps: none
+```
+
+Remove unused helper imports. Keep `pytest` when using `pytest.mark.parametrize` or `pytest.skip`; otherwise follow existing file style.
+
+## Case Mapping
+
+Convert each row in the route group's case table into one test function.
+
+Function names must be lowercase, underscore-separated, and non-abbreviated:
+
+```text
+test_<method>_<resource>_<case_description>
+```
+
+Examples: `test_post_projects_happy_path`, `test_post_projects_missing_name`, `test_get_project_unauthenticated`, `test_delete_project_not_found`.
+
+Parametric rows become one parametrized test, not multiple test functions:
+
+```python
+@pytest.mark.parametrize("body", [
+    {"description": "no name field"},
+    {"name": "", "description": "empty name"},
+])
+def test_post_projects_invalid_body(base_url, unique_user, body):
+    user_id, headers = unique_user
+    r = requests.post(f"{base_url}/projects", json=body, headers=headers)
+    assert r.status_code == 422
+```
+
+Multi-step stateful flows stay in one test function with step comments:
+
+```python
+def test_post_invites_accept_flow(base_url, unique_user):
+    user_id, headers = unique_user
+
+    # Step 1: create invite
+    r = requests.post(f"{base_url}/invites", json={"email": "x@example.com"}, headers=headers)
+    assert r.status_code == 201
+    token = r.json()["token"]
+
+    # Step 2: accept invite
+    r = requests.post(f"{base_url}/invites/{token}/accept", headers=headers)
+    assert r.status_code == 200
+```
+
+## Fixture Rules
+
+Use only fixtures already defined in `tests/<service>/conftest.py`.
+
+- Never define fixtures in test files.
+- Never modify `conftest.py`.
+- Never add or change helper files.
+- Use session-scoped fixtures such as `base_url` for the service URL.
+- Use function-scoped fixtures such as `unique_user` for identity and mutable resources.
+- Every test requiring auth gets its own identity via `unique_user` or the equivalent per-test fixture.
+- Never share user identity or mutable resource state between test functions at module level.
+
+If a needed fixture does not exist, implement the case as skipped and record the gap:
+
+```python
+def test_post_projects_owner_limit(base_url, unique_user):
+    pytest.skip("requires 'projects_at_limit' fixture - not yet in conftest")
+```
+
+## Auth
+
+Use the exact auth pattern from `conftest.py` or `helpers/auth.py`. Do not construct JWTs manually inside test functions.
+
+Valid fixture consumption examples are `user_id, headers = unique_user` or `token = unique_user["token"]` followed by the header pattern already used by the harness.
+
+## Requests And Assertions
+
+Assert only what the assigned plan section specifies.
+
+For happy paths, assert status code, response fields explicitly named in the plan, and side effects explicitly named in the plan. For failure paths, assert only status code unless the plan specifies an error response body.
+
+Allowed when the plan specifies `201` and an `id` field:
+
+```python
+assert r.status_code == 201
+body = r.json()
+assert "id" in body
+```
+
+Not allowed unless the plan mentions `created_at` format:
+
+```python
+assert body["created_at"].endswith("Z")
+```
+
+## Side Effects
+
+When the plan specifies a database, MinIO, cache, or upstream side effect, assert it with an existing helper after the request.
+
+```python
+def test_post_projects_happy_path(base_url, unique_user):
+    user_id, headers = unique_user
+    r = requests.post(f"{base_url}/projects", json={"name": "my project"}, headers=headers)
+    assert r.status_code == 201
+    project_id = r.json()["id"]
+
+    row = query_row("SELECT id FROM projects WHERE id = %s", project_id)
+    assert row is not None
+```
+
+Do not assert side effects for failure cases unless the plan explicitly requires them.
+
+## Stubbed Upstreams
+
+If the plan lists a stub contract, configure the fake before calling the service. Use only the API found in `tests/<service>/helpers/fakes.py`.
+
+```python
+def test_post_projects_upstream_failure(base_url, unique_user):
+    user_id, headers = unique_user
+    set_fake_response("users-service", "/users/{id}", status=503)
+    r = requests.post(f"{base_url}/projects", json={"name": "x"}, headers=headers)
+    assert r.status_code == 503
+```
+
+If the plan requires a real external API such as OAuth, an LLM provider, payment, or email, skip the case and record the gap.
+
+## Coverage Gaps
+
+End every test file with a coverage-gaps comment section.
+
+Include:
+
+- Plan rows not implemented, with reasons such as missing fixture, undefined stub contract, ambiguous status code, or external API dependency.
+- Routes from the assigned route group skipped for any reason.
+- Routes already visible from provided source/router context that match the group's URL pattern but are absent from the plan.
+
+If there are no gaps, write exactly:
+
+```python
+# Coverage Gaps: none
+```
+
+## Hard Rules
+
+Never do these:
+
+- Import from service source packages, such as `from app.models import Project`.
+- Define fixtures inside test files.
+- Modify `conftest.py` or helper files.
+- Share mutable state between test functions at module level.
+- Assert fields, side effects, or status codes not present in the plan.
+- Call real external APIs, including OAuth, LLM endpoints, payment, and email.
+- Infer behavior from service source to override the plan.
+- Write more than the one assigned route-group test file.
+
+## Validation
+
+After writing the test file, run collection for that file:
+
+```bash
+python -m pytest -c tests/<service>/pytest.ini tests/<service>/test_<file>.py --collect-only
+```
+
+Collection must succeed with zero errors before the task is done. If collection fails, fix import, syntax, or fixture errors and re-run collection.
+
+Do not run the full test file unless the harness stack is already running. If the stack is not running, successful `--collect-only` is sufficient.

--- a/.agent/skills/implement-integration-tests/agents/openai.yaml
+++ b/.agent/skills/implement-integration-tests/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Implement Integration Tests"
+  short_description: "Write SyncTeX pytest files from TEST_PLAN.md"
+  default_prompt: "Implement the assigned SyncTeX REST integration test route group from tests/<service>/TEST_PLAN.md as one pytest file, using only the existing conftest fixtures and helpers, then verify collection."

--- a/.agent/skills/plan-integration-tests/SKILL.md
+++ b/.agent/skills/plan-integration-tests/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: plan-integration-tests
+description: Generate a structured black-box integration test plan for a SyncTeX REST backend service after its test harness has been set up but before test cases are implemented. Use when given a service directory, route file, OpenAPI/schema, or a request such as "figure out what to test", "list the test cases", "plan integration tests", or "what should I test" for any SyncTeX REST backend service. Produces one markdown plan document and does not write test code.
+---
+
+# Plan Integration Tests
+
+Create a source-grounded integration test plan for one SyncTeX REST backend service. The output is a single markdown file at `tests/<service>/TEST_PLAN.md`. Do not implement tests or modify service source.
+
+## Workflow
+
+1. Confirm the target service directory from the user request. If missing and it cannot be inferred, ask for it before inspecting code.
+2. Inspect the service source before planning. Treat source code as ground truth even when an OpenAPI/schema file is provided.
+3. Enumerate every REST route with method, path, handler, auth requirement, request shape, response shape, side effects, and visible error behavior.
+4. Group routes by shared fixtures/state, then write route-level cases with exact expected statuses and side-effect assertions.
+5. Write only `tests/<service>/TEST_PLAN.md`.
+6. Report only counts, gaps, and required stub contracts after writing the file.
+
+## Source Inspection Checklist
+
+Read only enough code to make the plan executable by another agent without re-reading the service.
+
+**Routes and handlers**
+
+- Go/Gin: start with `main.go`, `router.go`, `routes.go`, handler packages, and middleware wiring.
+- FastAPI: start with `main.py`, `app/routers/`, `app/api/`, dependency modules, and middleware registration.
+- Record every route as `METHOD /path -> handler`. Do not skip health/readiness routes.
+
+**Auth**
+
+- Find JWT validation and identity extraction. Do not assume claim names or types.
+- Record claim key, claim value type, failure statuses, and which routes require auth.
+- Pay attention to SyncTeX polyglot claim mismatches: Python may use `sub`; Go services may use custom context keys such as `userId`; UUIDs are commonly strings.
+
+**Requests, responses, and validation**
+
+- For each route, find body/query/path schemas, required fields, optional fields, validation tags, Pydantic validators, binding rules, and response models.
+- Record only response fields and validation failures visible in code/schema.
+
+**Persistence and side effects**
+
+- Identify owned database tables, migrations, sqlc queries, repository methods, MinIO buckets/objects, presigned URL behavior, events, and background work.
+- Use these as first-class assertions in happy-path and relevant failure cases.
+
+**Errors**
+
+- Find explicit status codes, domain errors, middleware errors, and exception handlers.
+- Do not invent `404`, `409`, `422`, or `500` behavior. If code is ambiguous, mark it as requiring verification.
+
+**Cross-service dependencies**
+
+- Identify HTTP/gRPC calls to other SyncTeX services and external systems.
+- Record the call site, URL/method or RPC, request shape, and expected stub responses needed for happy-path and dependency-failure cases.
+
+## Test Grouping Rules
+
+Group routes by shared fixtures and state, usually by resource or flow.
+
+- Collection routes, such as `POST /projects` and `GET /projects`, should share a group.
+- Item routes, such as `GET /projects/:id`, `PATCH /projects/:id`, and `DELETE /projects/:id`, should share a group.
+- Stateful flows, such as invite creation and acceptance, should be their own group even when they span resources.
+- Health/readiness can be a small separate group if it has no shared auth/state.
+
+## Coverage Rules
+
+Every route must have at least:
+
+- One happy-path case.
+- One unauthenticated case if the route requires auth.
+- One malformed/invalid token case if middleware distinguishes it or the harness can produce it.
+- One case per required request field showing the actual validation failure.
+- One case per visible domain failure, such as not found, forbidden, duplicate, stale ETag, invalid owner, expired invite, or upstream failure.
+
+Apply these planning constraints:
+
+- Use parametric rows for repeated validation cases instead of expanding many near-identical rows.
+- Include side-effect assertions for any database, MinIO, cache, event, or upstream interaction.
+- For stateful flows, list steps in order and name the fixture/value that carries state between steps.
+- If a route has no interesting failures beyond auth and validation, state that explicitly.
+- If behavior cannot be verified from source/schema, include a note instead of guessing.
+
+## Output Format
+
+Write this exact structure, adapting section names to the service.
+
+```markdown
+# Integration Test Plan: <ServiceName>
+
+## Service Summary
+
+- Auth claim: `<key>` (`<type>`) - required on: <route patterns>
+- Owned persistence: <tables, buckets, caches, or "none">
+- Stubbed upstreams: <service/dependency names and contract summary, or "none">
+- Health endpoint: `GET <path>` -> <status> <response shape>
+- Source references: <key files inspected>
+
+## Test Groups
+
+### <Group Name>
+
+**Routes covered**: `METHOD /path`, `METHOD /path`
+**Fixtures needed**: <fixtures expected from the existing harness, plus new fixture names if needed>
+**Shared setup**: <state that must exist before cases run, or "none">
+
+#### `METHOD /path`
+
+| Case | Inputs | Expected status | Side effects | Notes |
+|------|--------|-----------------|--------------|-------|
+| Happy path | valid body + auth | 201 | row in `<table>` | response includes `<field>` |
+| Missing required field (`field`) | body without `field` + auth | 422 | none | parametrize over: `field_a`, `field_b` |
+| Unauthenticated | valid body, no token | 401 | none | auth middleware |
+| Domain failure | duplicate `<field>` + auth | 409 | none | only if code returns 409 |
+
+**Parameters**:
+
+```python
+valid_body = {"field": "value"}
+missing_required_fields = ["field"]
+```
+
+**Stub contracts**:
+
+- `<dependency>` happy path: request `<method/path/RPC>` with `<shape>` returns `<status/body>`.
+- `<dependency>` failure: request `<method/path/RPC>` returns `<status/error>` and service returns `<status>`.
+
+**Gotchas**: <non-obvious implementation details, or "none">
+```
+
+Repeat the route subsection for every route in the group. Keep the document implementation-ready, not prose-heavy.
+
+## Final Response
+
+After writing `tests/<service>/TEST_PLAN.md`, respond with:
+
+- Total route count.
+- Total planned test case count.
+- Routes or behaviors that could not be planned because source information was missing.
+- Cross-service stubs that need contracts before implementation can begin.
+
+Do not summarize the plan content in the conversation.

--- a/.agent/skills/plan-integration-tests/agents/openai.yaml
+++ b/.agent/skills/plan-integration-tests/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Plan Integration Tests"
+  short_description: "Plan black-box REST integration test cases for SyncTeX services."
+  default_prompt: "Plan black-box integration test cases for a SyncTeX REST backend service after the test harness has been set up."

--- a/.agent/skills/setup-service-integration-tests/SKILL.md
+++ b/.agent/skills/setup-service-integration-tests/SKILL.md
@@ -1,0 +1,228 @@
+---
+name: setup-service-integration-tests
+description: Set up service-specific black-box pytest integration test harnesses for SyncTeX backend services. Use when Codex needs to create or refine service test directories, Docker Compose test stacks, pytest fixtures, auth/storage/database helpers, and service-agnostic integration-test scaffolding without writing service-specific behavioral test cases or CI workflows.
+---
+
+# Setup Service Integration Tests
+
+## Overview
+
+Create a professional, service-specific black-box integration test harness for SyncTeX backend services. The harness should run the service under test in Docker Compose with real owned infrastructure, expose only test endpoints needed by pytest, and leave behavioral test cases for a separate task.
+
+## Operating Rules
+
+- Do not write service-specific behavioral tests unless the user explicitly asks. Set up structure, fixtures, helpers, and optional harness-only validation.
+- Do not add or mention CI workflow setup.
+- Prefer production Dockerfiles for the service under test unless the repo proves they cannot run in the test stack.
+- Keep each service stack minimal: include the service under test plus owned persistence/infrastructure; stub other SyncTeX services unless the requested setup explicitly requires full-stack behavior.
+- Keep tests black-box: pytest should call public HTTP endpoints from outside the service container instead of importing service internals.
+- Preserve existing repo conventions and AGENTS.md guidance. In SyncTeX, pay close attention to JWT claim names and types across languages.
+
+## Workflow
+
+1. Inspect the service directory, Dockerfiles, config loading, health/readiness endpoints, migrations, and cross-service dependencies.
+2. Create or update `tests/<service>/` with a service-owned test harness.
+3. Add `docker-compose.test.yml` that builds/runs the service and its owned test dependencies.
+4. Add `conftest.py` that manages stack lifecycle, waits for readiness, exposes clients/base URLs, and creates isolated identities/resources.
+5. Add helper modules for repo-wide concerns such as JWT minting, MinIO/S3 inspection, Postgres inspection, fake upstream services, and random IDs.
+6. Add `pytest.ini` and `requirements.txt` with only dependencies needed by the harness.
+7. Add one generic harness-validation health test when the service exposes a stable health/readiness endpoint.
+8. Validate with Docker Compose config rendering and pytest execution or collection.
+
+## Directory Shape
+
+Use this shape unless the repo already has a stronger convention:
+
+```text
+tests/<service>/
+  conftest.py
+  docker-compose.test.yml
+  pytest.ini
+  requirements.txt
+  helpers/
+    __init__.py
+```
+
+Add service-specific helper files only when needed, for example:
+
+```text
+helpers/
+  auth.py
+  db.py
+  minio.py
+  fake_upstream.py
+```
+
+Do not add README-style documentation to the harness unless the repo already documents tests that way.
+
+## Compose Stack Requirements
+
+`docker-compose.test.yml` should be deterministic, hermetic, and easy to tear down.
+
+Required properties:
+
+- Use test-only database names, credentials, secrets, buckets, and API keys.
+- Include real migrations for services with persistent schema.
+- Use health checks for infrastructure containers.
+- Expose the service under test to localhost on a test port.
+- Put all services on a dedicated test network.
+- Avoid `container_name`; let Compose namespace containers through project names.
+- Avoid persistent named volumes unless there is a reason. Prefer anonymous volumes or explicit teardown with `down --volumes --remove-orphans`.
+- Set dummy values for unused dependencies so startup succeeds without pulling in the entire SyncTeX graph.
+- Use fake/stub containers for required upstream services that are not under test.
+- Make internal Docker hostnames match service config, then expose external hostnames only where clients need them.
+
+Preferred service naming:
+
+```yaml
+services:
+  <service>-test:
+  postgres-test:
+  minio-test:
+  migrate-test:
+  fake-<upstream>-test:
+```
+
+Use a unique Compose project name from pytest rather than hard-coded container names:
+
+```python
+COMPOSE_PROJECT_NAME = f"sync-tex-{SERVICE_NAME}-test-{uuid.uuid4().hex[:8]}"
+```
+
+Pass it to Compose:
+
+```python
+env = {**os.environ, "COMPOSE_PROJECT_NAME": COMPOSE_PROJECT_NAME}
+subprocess.run(["docker", "compose", "-f", COMPOSE_FILE, *args], env=env, check=True)
+```
+
+## Pytest Lifecycle
+
+Use a session-scoped autouse fixture to own the stack lifecycle:
+
+```python
+@pytest.fixture(scope="session", autouse=True)
+def docker_stack():
+    compose("up", "--build", "--detach")
+    try:
+        wait_for_health(HEALTH_URL)
+        yield
+    finally:
+        compose("down", "--volumes", "--remove-orphans")
+```
+
+Implement readiness polling with a deadline and last-error reporting. Do not rely only on `depends_on`; the service endpoint should be ready before tests run.
+
+Expose simple fixtures:
+
+```python
+@pytest.fixture(scope="session")
+def base_url():
+    return SERVICE_URL
+
+@pytest.fixture
+def unique_id():
+    return str(uuid.uuid4())
+```
+
+For authenticated services, add per-test identity fixtures that mint tokens with the exact claim shape accepted by the service under test:
+
+```python
+@pytest.fixture
+def unique_user():
+    user_id = str(uuid.uuid4())
+    token = mint_token(user_id, secret=JWT_SECRET)
+    return user_id, {"Authorization": f"Bearer {token}"}
+```
+
+Do not assume `sub`, `user_id`, numeric IDs, or string IDs. Inspect the service middleware/config and make the helper match reality.
+
+## Dependency Harness Patterns
+
+Use these patterns consistently across backend services:
+
+- **Postgres**: run a service-specific Postgres container, use test credentials, wait on `pg_isready`, run real migrations before service startup, and tear down volumes.
+- **MinIO/S3**: run MinIO when the service owns object-storage behavior. Configure internal endpoint for containers and external endpoint for pytest/client-visible presigned URLs.
+- **Other SyncTeX services**: use fake HTTP/gRPC servers unless this harness is intentionally testing a real cross-service integration.
+- **External providers**: never call real OAuth, LLM, email, payment, or third-party APIs in service integration setup. Provide fake endpoints, dummy keys, or stubs.
+
+## Helper Standards
+
+Helpers should be thin and test-facing. They should not become a second implementation of the service.
+
+Recommended helpers:
+
+- `helpers/auth.py`: token minting and auth header construction.
+- `helpers/db.py`: optional database inspection for side-effect assertions.
+- `helpers/minio.py`: object existence/listing helpers.
+- `helpers/http.py`: small request helpers only when they reduce boilerplate without hiding behavior.
+- `helpers/fakes.py`: fake upstream-service response setup when needed.
+
+Keep secrets and endpoints in one place, matching `docker-compose.test.yml`.
+
+## Pytest Config
+
+Use a local `pytest.ini`:
+
+```ini
+[pytest]
+timeout = 60
+addopts = -v --tb=short
+timeout_func_only = true
+```
+
+Use `requirements.txt` for harness dependencies. Start minimal:
+
+```text
+pytest>=8.0
+requests>=2.31
+pytest-timeout>=2.3
+```
+
+Add only what the harness uses, such as `PyJWT`, `boto3`, or `psycopg`.
+
+## Harness Validation Test
+
+If the service exposes a stable health/readiness endpoint, add exactly one generic test that proves the test harness works end-to-end. Name it clearly, for example `test_health.py` or `test_harness.py`.
+
+Example:
+
+```python
+import requests
+
+
+def test_service_health(base_url):
+    r = requests.get(f"{base_url}/health", timeout=5)
+    assert r.status_code == 200
+```
+
+Keep this test limited to harness validation. Do not add domain-specific API assertions, persistence assertions, permission assertions, or service behavior coverage unless the user explicitly asks for test cases.
+
+## Validation
+
+After setup, run checks that validate the harness without adding service-specific behavior:
+
+```bash
+docker compose -f tests/<service>/docker-compose.test.yml config
+python -m pytest -c tests/<service>/pytest.ini tests/<service>
+```
+
+If the service has no stable health/readiness endpoint yet, use `--collect-only` instead of full pytest execution and state that executable harness validation is blocked until such an endpoint exists.
+
+Also verify cleanup works:
+
+```bash
+docker compose -f tests/<service>/docker-compose.test.yml down --volumes --remove-orphans
+```
+
+## Quality Bar
+
+The finished setup should make future behavioral tests straightforward:
+
+- A test author can import fixtures and immediately call the service API.
+- Each pytest run starts from clean infrastructure.
+- Tests can run repeatedly without manual cleanup.
+- Secrets, ports, database names, and buckets are test-only.
+- Cross-service dependencies are explicit and intentionally real or fake.
+- The stack can be debugged with ordinary `docker compose logs`.
+- The harness does not depend on the developer’s dev stack already running.

--- a/.agent/skills/setup-service-integration-tests/agents/openai.yaml
+++ b/.agent/skills/setup-service-integration-tests/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Setup Service Integration Tests"
+  short_description: "Build black-box service test harnesses."
+  default_prompt: "Set up a service-specific black-box pytest integration test harness for a SyncTeX backend service."

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,80 @@
+# Tests
+
+This directory contains service-scoped pytest integration test harnesses for
+SyncTeX backend services. Tests here should exercise services through their
+public HTTP, WebSocket, gRPC, storage, or container boundaries instead of
+importing private implementation details.
+
+## Directory Layout
+
+- Each service gets its own subdirectory, for example `tests/projects-service/`.
+- A service test directory owns its test harness: `conftest.py`, Docker Compose
+  test stack files, helper modules, requirements, and route-group test files.
+- Test files should be organized by externally visible behavior, route group, or
+  protocol surface. Do not mirror private source layout when that makes
+  black-box integration tests harder to understand.
+- Put reusable service-specific setup in that service's `conftest.py` or
+  `helpers/` package instead of duplicating clients, auth tokens, database
+  setup, or storage setup across test files.
+
+## Python Style
+
+- Use clear test, fixture, and helper names that describe behavior and expected
+  outcomes.
+- Add docstrings to fixtures and helpers when their purpose, lifecycle, or
+  return shape is not obvious.
+- Use type hints for public helpers, fixtures with non-obvious return values,
+  and complex data structures.
+- Do not add type hints to every local variable.
+- Keep helper functions small and focused. Avoid broad abstractions until
+  repeated setup or assertions are clearly shared.
+- Prefer explicit assertions over clever loops or generated checks that hide the
+  failing condition.
+- Keep comments rare and useful. Comments should explain intent, lifecycle, or
+  cross-service assumptions, not restate the code.
+
+## Pytest Style
+
+- Follow the Arrange, Act, Assert pattern. Use whitespace or short comments when
+  needed to make the three phases easy to scan.
+- Use `@pytest.mark.parametrize` when the same behavior should be checked across
+  multiple inputs, roles, status codes, or payload variants.
+- Prefer the `mocker` fixture from `pytest-mock` over
+  `unittest.mock.patch` for scoped mocks.
+- Use `yield` fixtures for setup that requires explicit teardown.
+- Keep fixture scopes as narrow as practical. Use `session` scope only for
+  expensive shared resources such as Docker stacks.
+- Do not make tests depend on execution order.
+- Prefer per-test unique users, projects, buckets, object names, or IDs over
+  global cleanup when isolation is simpler.
+- Assert response status codes before reading response bodies.
+- Include response text or JSON in assertion messages when diagnosing API
+  failures would otherwise be difficult.
+- Configure default pytest behavior in versioned pytest config files instead of
+  hardcoding flags in commands. Prefer a root `pyproject.toml` for new shared
+  pytest defaults; service-local config is acceptable only when the setting is
+  genuinely service-specific.
+
+## Integration Test Rules
+
+- Treat tests as black-box checks unless a test plan explicitly calls for a
+  narrower unit or component test.
+- Prefer real service dependencies from the test harness over mocks. Mock only
+  external systems that are unavailable, slow, nondeterministic, or outside the
+  route group being tested.
+- Validate auth behavior with JWT claims that match the service contract. In
+  this repo, `sub` claim type mismatches are a common failure source.
+- Keep MinIO behavior aligned with production expectations: services may rewrite
+  presigned URLs, and nginx does not proxy object payloads.
+- For Yjs-related tests, treat update payloads as binary protocol data unless
+  the owning service explicitly decodes them.
+- Document any intentionally accepted ambiguity, such as APIs that may return
+  either `403` or `404` to avoid disclosing resource existence.
+
+## Agent Expectations
+
+- Read this file before adding or modifying pytest tests under `tests/`.
+- Reuse existing fixtures and helpers before adding new ones.
+- If a generated test violates one of these standards for a practical reason,
+  leave a short comment in the code or explain the tradeoff in the final
+  response.


### PR DESCRIPTION
# docs/agent-test-generation-skills

## Summary
- Adds a repository-local integration testing playbook under `tests/` so agents follow SyncTeX-specific black-box pytest conventions, service ownership boundaries, and common cross-service pitfalls.
- Adds three local agent skills that cover the REST backend integration-test lifecycle: setting up service harnesses, planning route-group coverage, and implementing one planned route group as pytest tests.
- Exposes each new skill through companion OpenAI agent metadata so the local agent toolchain can discover the setup, planning, and implementation workflows consistently.

## Changes
### Commits
- `32dc98b` docs(agent): add service integration test setup skill.
  Context: Add a new local skill that guides setup of black-box pytest integration harnesses for SyncTeX REST backend services. Include the companion OpenAI agent metadata so the skill can be surfaced and invoked consistently from the local agent toolchain.
- `3d2f637` feat(agent): add integration test planning skill.
  Context: Add a new `plan-integration-tests` skill for generating source-grounded black-box REST integration test plans for SyncTeX backend services. Include the paired agent metadata so the capability is exposed with a clear display name and default prompt.
- `75b2db9` feat(agent): add integration test implementation skill.
  Context: Add a new `implement-integration-tests` skill for turning one assigned `TEST_PLAN.md` route group into a single pytest integration test file using the existing harness fixtures and helpers. Include the paired agent metadata so the skill is exposed with a focused display name and default prompt.
- `091f01f` docs(agent): add tests workspace instructions.
  Context: Add a repository-local AGENTS guide for integration tests under `tests/`. The document defines directory layout, pytest style, black-box integration rules, and repo-specific expectations such as JWT `sub` claim handling and MinIO/Yjs behavior.

### Files
- `.agent/skills/implement-integration-tests/SKILL.md` (added)
- `.agent/skills/implement-integration-tests/agents/openai.yaml` (added)
- `.agent/skills/plan-integration-tests/SKILL.md` (added)
- `.agent/skills/plan-integration-tests/agents/openai.yaml` (added)
- `.agent/skills/setup-service-integration-tests/SKILL.md` (added)
- `.agent/skills/setup-service-integration-tests/agents/openai.yaml` (added)
- `tests/AGENTS.md` (added)

## Related Issues
- Relates to #52
