### PR TITLE
Fix/projects service integration tests

### DIFF
--- a/tests/projects-service/conftest.py
+++ b/tests/projects-service/conftest.py
@@ -19,6 +19,7 @@ import requests
 # ── Config ────────────────────────────────────────────────────────────────────
 
 COMPOSE_FILE = os.path.join(os.path.dirname(__file__), "docker-compose.test.yml")
+COMPOSE_PROJECT_NAME = f"sync-tex-projects-service-test-{uuid.uuid4().hex[:8]}"
 SERVICE_URL = "http://localhost:8099"
 HEALTH_URL = f"{SERVICE_URL}/health"
 JWT_SECRET = "test-jwt-secret-for-integration-tests"  # must match compose env
@@ -32,11 +33,13 @@ STACK_STARTUP_TIMEOUT = 120
 
 def _compose(*args):
     """Run a docker compose command against the test compose file."""
+    env = {**os.environ, "COMPOSE_PROJECT_NAME": COMPOSE_PROJECT_NAME}
     return subprocess.run(
         ["docker", "compose", "-f", COMPOSE_FILE, *args],
         check=True,
         capture_output=True,
         text=True,
+        env=env,
     )
 
 
@@ -75,11 +78,7 @@ def docker_stack():
     """
     print("\n[conftest] Building and starting test stack...")
     try:
-        subprocess.run(
-            ["docker", "compose", "-f", COMPOSE_FILE, "up", "--build", "--detach"],
-            check=True,
-            text=True,
-        )
+        _compose("up", "--build", "--detach")
     except subprocess.CalledProcessError as e:
         raise
 

--- a/tests/projects-service/conftest.py
+++ b/tests/projects-service/conftest.py
@@ -22,6 +22,7 @@ COMPOSE_FILE = os.path.join(os.path.dirname(__file__), "docker-compose.test.yml"
 SERVICE_URL = "http://localhost:8099"
 HEALTH_URL = f"{SERVICE_URL}/health"
 JWT_SECRET = "test-jwt-secret-for-integration-tests"  # must match compose env
+MINIO_BUCKETS = ("uploads", "snapshot", "text")
 
 # How long to wait for the stack to become healthy (seconds)
 STACK_STARTUP_TIMEOUT = 120
@@ -57,6 +58,14 @@ def _wait_healthy(url: str, timeout: int = STACK_STARTUP_TIMEOUT):
     )
 
 
+def _ensure_minio_buckets():
+    """Create object-storage buckets required by projects-service handlers."""
+    from helpers.minio import ensure_bucket
+
+    for bucket in MINIO_BUCKETS:
+        ensure_bucket(bucket)
+
+
 @pytest.fixture(scope="session", autouse=True)
 def docker_stack():
     """
@@ -77,6 +86,7 @@ def docker_stack():
     try:
         print(f"[conftest] Waiting for {HEALTH_URL} ...")
         _wait_healthy(HEALTH_URL)
+        _ensure_minio_buckets()
         print("[conftest] Stack is healthy — running tests.")
         yield
     finally:

--- a/tests/projects-service/docker-compose.test.yml
+++ b/tests/projects-service/docker-compose.test.yml
@@ -3,7 +3,6 @@ version: "3.8"
 services:
   postgres-test:
     image: postgres:16-alpine
-    container_name: postgres-projects-test
     environment:
       POSTGRES_USER: testuser
       POSTGRES_PASSWORD: testpassword
@@ -20,7 +19,6 @@ services:
 
   minio-test:
     image: minio/minio:latest
-    container_name: minio-test
     command: server /data --console-address ":9001"
     environment:
       MINIO_ROOT_USER: testaccess
@@ -39,7 +37,6 @@ services:
   # Run projects-service-db migrations
   migrate-test:
     image: migrate/migrate
-    container_name: migrate-projects-test
     volumes:
       - ../../projects-service/db/migrations:/migrations
     command: >
@@ -58,7 +55,6 @@ services:
     build:
       context: ../../projects-service
       dockerfile: Dockerfile
-    container_name: projects-service-test
     environment:
       # Dummy values used for testing
       DATABASE_URL: postgres://testuser:testpassword@postgres-test:5432/projects_test?sslmode=disable

--- a/tests/projects-service/helpers/minio.py
+++ b/tests/projects-service/helpers/minio.py
@@ -32,6 +32,18 @@ def minio_client():
     )
 
 
+def ensure_bucket(bucket: str):
+    """Create the bucket if it does not already exist."""
+    client = minio_client()
+    try:
+        client.head_bucket(Bucket=bucket)
+    except ClientError as e:
+        code = e.response["Error"].get("Code")
+        if code not in ("404", "NoSuchBucket"):
+            raise
+        client.create_bucket(Bucket=bucket)
+
+
 def object_exists(bucket: str, key: str) -> bool:
     """Return True if the object exists in the given bucket."""
     client = minio_client()

--- a/tests/projects-service/test_files.py
+++ b/tests/projects-service/test_files.py
@@ -13,11 +13,22 @@ Endpoints covered:
 """
 
 import uuid
-import pytest
 import requests
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
+
+def get_root_directory_id(base_url, proj_id, headers):
+    r = requests.get(
+        f"{base_url}/projects/v1/projects/{proj_id}/tree",
+        headers=headers,
+    )
+    assert r.status_code == 200, f"project tree setup failed: {r.status_code} {r.text}"
+
+    tree = r.json().get("tree", [])
+    assert tree, f"project tree has no root directory: {r.text}"
+    return tree[0]["id"]
+
 
 def create_file(base_url, proj_id, headers, filename="test.txt", directory_id=None, file_type="tex"):
     body = {"filename": filename, "file_type": file_type}
@@ -43,7 +54,14 @@ def create_directory(base_url, proj_id, headers, name="subdir", path="/"):
 class TestCreateFile:
     def test_create_file_returns_201_and_presigned_url(self, base_url, project):
         proj, headers = project
-        r = create_file(base_url, proj["id"], headers, filename="hello.txt")
+        directory_id = get_root_directory_id(base_url, proj["id"], headers)
+        r = create_file(
+            base_url,
+            proj["id"],
+            headers,
+            filename="hello.txt",
+            directory_id=directory_id,
+        )
         assert r.status_code == 201
         data = r.json()
         assert "id" in data
@@ -52,16 +70,30 @@ class TestCreateFile:
         assert upload_url is not None, f"Expected a presigned URL in response: {data}"
 
     def test_create_file_without_auth_returns_401(self, base_url, project):
-        proj, _ = project
-        r = create_file(base_url, proj["id"], headers={}, filename="nope.txt")
+        proj, headers = project
+        directory_id = get_root_directory_id(base_url, proj["id"], headers)
+        r = create_file(
+            base_url,
+            proj["id"],
+            headers={},
+            filename="nope.txt",
+            directory_id=directory_id,
+        )
         assert r.status_code == 401
 
     def test_create_file_non_member_returns_403_or_404(
         self, base_url, project, second_user
     ):
-        proj, _ = project
+        proj, headers = project
         _, headers_b = second_user
-        r = create_file(base_url, proj["id"], headers_b, filename="intruder.txt")
+        directory_id = get_root_directory_id(base_url, proj["id"], headers)
+        r = create_file(
+            base_url,
+            proj["id"],
+            headers_b,
+            filename="intruder.txt",
+            directory_id=directory_id,
+        )
         assert r.status_code in (403, 404)
 
 
@@ -69,7 +101,14 @@ class TestGetFile:
     def test_get_file_metadata(self, base_url, project):
         proj, headers = project
         # Create a file first
-        r = create_file(base_url, proj["id"], headers, filename="readable.txt")
+        directory_id = get_root_directory_id(base_url, proj["id"], headers)
+        r = create_file(
+            base_url,
+            proj["id"],
+            headers,
+            filename="readable.txt",
+            directory_id=directory_id,
+        )
         assert r.status_code == 201
         file_id = r.json()["id"]
 
@@ -92,7 +131,14 @@ class TestGetFile:
 class TestUpdateFile:
     def test_rename_file(self, base_url, project):
         proj, headers = project
-        r = create_file(base_url, proj["id"], headers, filename="original.txt")
+        directory_id = get_root_directory_id(base_url, proj["id"], headers)
+        r = create_file(
+            base_url,
+            proj["id"],
+            headers,
+            filename="original.txt",
+            directory_id=directory_id,
+        )
         assert r.status_code == 201
         file_id = r.json()["id"]
 
@@ -109,12 +155,20 @@ class TestUpdateFile:
     ):
         proj, headers = project
         _, headers_b = second_user
-        r = create_file(base_url, proj["id"], headers, filename="mine.txt")
+        directory_id = get_root_directory_id(base_url, proj["id"], headers)
+        r = create_file(
+            base_url,
+            proj["id"],
+            headers,
+            filename="mine.txt",
+            directory_id=directory_id,
+        )
+        assert r.status_code == 201, f"file setup failed: {r.status_code} {r.text}"
         file_id = r.json()["id"]
 
         r = requests.patch(
             f"{base_url}/projects/v1/projects/{proj['id']}/files/{file_id}",
-            json={"name": "stolen.txt"},
+            json={"filename": "stolen.txt"},
             headers=headers_b,
         )
         assert r.status_code in (403, 404)
@@ -123,7 +177,14 @@ class TestUpdateFile:
 class TestDeleteFile:
     def test_delete_file(self, base_url, project):
         proj, headers = project
-        r = create_file(base_url, proj["id"], headers, filename="bye.txt")
+        directory_id = get_root_directory_id(base_url, proj["id"], headers)
+        r = create_file(
+            base_url,
+            proj["id"],
+            headers,
+            filename="bye.txt",
+            directory_id=directory_id,
+        )
         assert r.status_code == 201
         file_id = r.json()["id"]
 
@@ -144,7 +205,14 @@ class TestDeleteFile:
 class TestUploadURL:
     def test_get_upload_url_for_existing_file(self, base_url, project):
         proj, headers = project
-        r = create_file(base_url, proj["id"], headers, filename="uploadme.txt")
+        directory_id = get_root_directory_id(base_url, proj["id"], headers)
+        r = create_file(
+            base_url,
+            proj["id"],
+            headers,
+            filename="uploadme.txt",
+            directory_id=directory_id,
+        )
         assert r.status_code == 201
         file_id = r.json()["id"]
 
@@ -162,7 +230,15 @@ class TestUploadURL:
     ):
         proj, headers = project
         _, headers_b = second_user
-        r = create_file(base_url, proj["id"], headers, filename="secure.txt")
+        directory_id = get_root_directory_id(base_url, proj["id"], headers)
+        r = create_file(
+            base_url,
+            proj["id"],
+            headers,
+            filename="secure.txt",
+            directory_id=directory_id,
+        )
+        assert r.status_code == 201, f"file setup failed: {r.status_code} {r.text}"
         file_id = r.json()["id"]
 
         r = requests.post(

--- a/tests/projects-service/test_projects.py
+++ b/tests/projects-service/test_projects.py
@@ -8,11 +8,10 @@ Endpoints covered:
     PATCH  /projects/v1/projects/{projectID}
     DELETE /projects/v1/projects/{projectID}
     GET    /projects/v1/projects/{projectID}/tree
-    GET    /projects/v1/access
+    GET    /projects/v1/projects/{projectID}/access
 """
 
 import uuid
-import pytest
 import requests
 
 
@@ -189,15 +188,13 @@ class TestAccess:
     def test_owner_has_owner_role(self, base_url, project):
         proj, headers = project
         r = requests.get(
-            f"{base_url}/projects/v1/access",
-            params={"project_id": proj["id"]},
+            f"{base_url}/projects/v1/projects/{proj['id']}/access",
             headers=headers,
         )
         assert r.status_code == 200
         data = r.json()
-        # Adjust key name to match actual API response shape
-        role = data.get("role") or data.get("permission")
-        assert role is not None
+        assert data["allowed"] is True
+        assert data["role"] == "owner"
 
     def test_non_member_access_returns_403_or_404(
         self, base_url, project, second_user
@@ -205,8 +202,9 @@ class TestAccess:
         proj, _ = project
         _, headers_b = second_user
         r = requests.get(
-            f"{base_url}/projects/v1/access",
-            params={"project_id": proj["id"]},
+            f"{base_url}/projects/v1/projects/{proj['id']}/access",
             headers=headers_b,
         )
         assert r.status_code in (403, 404)
+        if r.status_code == 403:
+            assert r.json()["allowed"] is False


### PR DESCRIPTION
# fix/projects-service-integration-tests

## Summary
- This branch packages 3 local commits across `projects-service`.
- It includes: isolate integration test compose stacks; update integration tests for current file and access contracts; provision required MinIO buckets in integration tests.
- File-level impact: 5 updated.
- Implementation context: Generate a unique COMPOSE_PROJECT_NAME for each projects-service pytest session and route setup through the shared compose helper so startup and teardown use the same stack identity. Remove fixed container_name declarations from the test compose file so Docker Compose can namespace containers, networks, and related resources per session. Resolve stale test assumptions around file creation, rename payloads, and access-check routing. The suite now fetches the root directory before creating files and asserts against the current access response fields so failures point to real regressions instead of old API expectations.

## Changes
### Commits
- `894d5b9` fix(projects-service): provision required MinIO buckets in integration tests.
  Context: Create the uploads, snapshot, and text buckets during projects-service test stack startup. This keeps the shared harness aligned with the service's storage assumptions and avoids setup failures in file-related test cases.
- `e23a278` test(projects-service): update integration tests for current file and access contracts.
  Context: Resolve stale test assumptions around file creation, rename payloads, and access-check routing. The suite now fetches the root directory before creating files and asserts against the current access response fields so failures point to real regressions instead of old API expectations.
- `38944c0` fix(projects-service): isolate integration test compose stacks.
  Context: Generate a unique COMPOSE_PROJECT_NAME for each projects-service pytest session and route setup through the shared compose helper so startup and teardown use the same stack identity. Remove fixed container_name declarations from the test compose file so Docker Compose can namespace containers, networks, and related resources per session.

### Files
- `tests/projects-service/conftest.py` (updated)
- `tests/projects-service/docker-compose.test.yml` (updated)
- `tests/projects-service/helpers/minio.py` (updated)
- `tests/projects-service/test_files.py` (updated)
- `tests/projects-service/test_projects.py` (updated)

## Related Issues
- Resolves #61
- Relates to #52
