### PR TITLE
Build/add named tunnel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,8 @@
 
 
 # Host Config
-FRONTEND_URL=http://localhost
-EXTERNAL_URL=http://localhost
+FRONTEND_URL=https://sync-tex.com
+EXTERNAL_URL=https://sync-tex.com
 
 
 # Swarm CD deployment
@@ -73,7 +73,7 @@ MINIO_ROOT_PASSWORD=minio_root_password
 # Internal service access
 MINIO_ENDPOINT=minio:9000
 # External access through nginx
-MINIO_EXTERNAL_ENDPOINT=http://localhost/minio/api
+MINIO_EXTERNAL_ENDPOINT=https://sync-tex.com/minio/api
 MINIO_ACCESS_KEY=minio_access_key
 MINIO_SECRET_KEY=minio_secret_key
 

--- a/cloudflared/config.yml
+++ b/cloudflared/config.yml
@@ -1,0 +1,7 @@
+tunnel: ffab8018-a347-428e-8bac-e1c74a7cde3d
+credentials-file: /etc/cloudflared/ffab8018-a347-428e-8bac-e1c74a7cde3d.json
+
+ingress:
+  - hostname: sync-tex.com
+    service: http://nginx:80
+  - service: http_status:404

--- a/docker-compose.swarm.yml
+++ b/docker-compose.swarm.yml
@@ -1,11 +1,6 @@
 services:
   nginx:
     image: ${REGISTRY_IMAGE_PREFIX:-ghcr.io/ameb8/sync-tex}/nginx:${NGINX_TAG:-latest}
-    ports:
-      - target: 80
-        published: 80
-        protocol: tcp
-        mode: ingress
     networks:
       - gateway-network
     stop_grace_period: 30s
@@ -276,9 +271,17 @@ services:
 
   cloudflared:
     image: cloudflare/cloudflared:latest
-    command: tunnel --no-autoupdate --url http://nginx:80
+    command: tunnel --no-autoupdate --config /etc/cloudflared/config.yml run
     networks:
       - gateway-network
+    configs:
+      - source: cloudflared_config
+        target: /etc/cloudflared/config.yml
+        mode: 0444
+    secrets:
+      - source: cloudflared_creds
+        target: /etc/cloudflared/ffab8018-a347-428e-8bac-e1c74a7cde3d.json
+        mode: 0400
     deploy:
       replicas: 1
       restart_policy:
@@ -292,6 +295,14 @@ volumes:
   postgres_projects_data:
   postgres_assistant_data:
   minio_data:
+
+configs:
+  cloudflared_config:
+    external: true
+
+secrets:
+  cloudflared_creds:
+    external: true
 
 networks:
   gateway-network:

--- a/docs/deployment-runbook.md
+++ b/docs/deployment-runbook.md
@@ -17,6 +17,8 @@ docker stack deploy --with-registry-auth --resolve-image always -c docker-compos
 
 - Docker Engine and Docker Compose plugin installed.
 - Single-node Swarm initialized.
+- Cloudflare owns `sync-tex.com` and `cloudflared` is installed on the
+  production host.
 - Self-hosted GitHub Actions runner installed with labels:
   `self-hosted`, `linux`, `ARM64`, `synctex-prod`.
 - Runner user can execute Docker commands.
@@ -85,7 +87,8 @@ chmod 600 .env
 
 Production values must include at least:
 
-- `FRONTEND_URL` and `EXTERNAL_URL` set to the public origin.
+- `FRONTEND_URL=https://sync-tex.com`.
+- `EXTERNAL_URL=https://sync-tex.com`.
 - Strong database passwords for all three Postgres services.
 - `USERS_SECRET_KEY`, `USERS_INTERNAL_API_KEY`, and
   `PROJECTS_INTERNAL_API_KEY`.
@@ -103,6 +106,12 @@ USERS_INTERNAL_API_URL=http://users-service:8001
 PROJECTS_SERVICE_URL=http://projects-service:8003
 FILE_DATA_ADDR=file-data-service:50051
 MINIO_ENDPOINT=minio:9000
+```
+
+Keep browser-facing MinIO URLs on the public HTTPS origin:
+
+```env
+MINIO_EXTERNAL_ENDPOINT=https://sync-tex.com/minio/api
 ```
 
 Do not commit `.env`, copy it into GitHub secrets, or expose it to
@@ -136,7 +145,68 @@ If images are public and the workflow passes registry auth during deploy, this
 manual login may not be necessary. It is still useful for manual recovery and
 manual deploys.
 
-### 6. Install The Self-Hosted GitHub Runner
+### 6. Create The Named Cloudflare Tunnel
+
+Create the named tunnel once on the production Pi. This can be run from any
+directory; `cloudflared` writes the credentials JSON under the home directory
+of the user running the command.
+
+```sh
+cloudflared tunnel login
+cloudflared tunnel create synctex
+```
+
+Record the tunnel UUID from the command output. The UUID is not a secret, but
+the generated credentials JSON is a secret. The credentials file is normally:
+
+```text
+~/.cloudflared/<tunnel-uuid>.json
+```
+
+Before deploying, the repository version of these files must contain the real
+UUID, not `<tunnel-id>`:
+
+- `cloudflared/config.yml`
+- `docker-compose.swarm.yml`, in the `cloudflared_creds` secret target path
+
+The committed config should look like this, with the real UUID in both paths:
+
+```yaml
+tunnel: <tunnel-uuid>
+credentials-file: /etc/cloudflared/<tunnel-uuid>.json
+
+ingress:
+  - hostname: sync-tex.com
+    service: http://nginx:80
+  - service: http_status:404
+```
+
+Create the DNS route in Cloudflare:
+
+```sh
+cloudflared tunnel route dns synctex sync-tex.com
+```
+
+The stack uses externally managed Swarm objects for the tunnel config and
+credentials. Create them before the first deploy from the production checkout:
+
+```sh
+cd /opt/synctex
+docker config create cloudflared_config ./cloudflared/config.yml
+docker secret create cloudflared_creds ~/.cloudflared/<tunnel-uuid>.json
+```
+
+Validate that both objects exist:
+
+```sh
+docker config ls | grep cloudflared_config
+docker secret ls | grep cloudflared_creds
+```
+
+Do not commit the credentials JSON, copy it into `.env`, or store it in GitHub
+secrets. Only the UUID and `cloudflared/config.yml` are tracked.
+
+### 7. Install The Self-Hosted GitHub Runner
 
 In GitHub, create a repository self-hosted runner and follow GitHub's generated
 installation commands on the Pi. Configure it with these labels:
@@ -169,7 +239,7 @@ docker stack ls
 The self-hosted runner is for deployment only. Build jobs must run on
 GitHub-hosted `ubuntu-latest` runners.
 
-### 7. Ensure Initial Images Exist
+### 8. Ensure Initial Images Exist
 
 Before the first stack deploy, GHCR must contain ARM64 images tagged `latest`
 for:
@@ -200,7 +270,7 @@ Repeat for each deployable image. `file-data-service` needs the root proto
 additional build context, so prefer the GitHub workflow for the first full
 image bootstrap.
 
-### 8. Run The First Deploy
+### 9. Run The First Deploy
 
 From the production checkout, run:
 
@@ -226,23 +296,25 @@ If the first deploy fails, inspect task errors before retrying:
 docker stack services synctex
 docker stack ps synctex --no-trunc
 docker service logs synctex_projects-service
+docker service logs synctex_cloudflared
 ```
 
 Do not delete volumes during troubleshooting unless you intentionally want to
 discard production data.
 
-### 9. Validate The First Deploy
+### 10. Validate The First Deploy
 
 From the Pi:
 
 ```sh
 docker stack services synctex
 docker stack ps synctex
-curl -fsS http://127.0.0.1/health
 ```
 
 Then validate the public route through cloudflared:
 
+- Gateway health:
+  `curl -fsS https://sync-tex.com/health`
 - GitHub OAuth login and redirect.
 - Authenticated project listing.
 - File upload/download through presigned MinIO URLs.
@@ -285,6 +357,107 @@ For the first bootstrap, the script deploys the stack once to create the Swarm
 network and databases, waits for stateful services, runs migrations, then
 redeploys and waits for the full stack.
 
+The deploy script does not create or update the external Swarm objects used by
+`cloudflared`. `cloudflared_config` and `cloudflared_creds` must already exist
+before `scripts/deploy-stack.sh` runs.
+
+## Cloudflare Tunnel Management
+
+The named tunnel has three separate pieces:
+
+- Cloudflare tunnel identity: the UUID created by `cloudflared tunnel create`.
+- Swarm config: `cloudflared_config`, created from `cloudflared/config.yml`.
+- Swarm secret: `cloudflared_creds`, created from
+  `~/.cloudflared/<tunnel-uuid>.json`.
+
+The UUID is safe to track in Git. The credentials JSON is secret and must stay
+on the production host only.
+
+### Inspect Current State
+
+Run these commands on the production Pi:
+
+```sh
+cloudflared tunnel list
+docker config ls | grep cloudflared_config
+docker secret ls | grep cloudflared_creds
+docker service logs synctex_cloudflared --tail 100
+```
+
+To inspect the deployed config content:
+
+```sh
+docker config inspect cloudflared_config --pretty
+```
+
+### Updating `cloudflared/config.yml`
+
+Swarm configs are immutable. If `cloudflared/config.yml` changes in Git, a
+normal `git pull` and `scripts/deploy-stack.sh` is not enough; the external
+Docker config must be recreated.
+
+Because the current stack references the fixed external name
+`cloudflared_config`, recreate it during a planned maintenance window:
+
+```sh
+cd /opt/synctex
+docker stack rm synctex
+
+until [ -z "$(docker stack ps synctex 2>/dev/null)" ]; do
+  sleep 2
+done
+
+docker config rm cloudflared_config
+docker config create cloudflared_config ./cloudflared/config.yml
+scripts/deploy-stack.sh
+```
+
+Use this flow for ingress rule changes, hostname changes, or a changed tunnel
+UUID in `cloudflared/config.yml`.
+
+### Rotating Tunnel Credentials
+
+If the tunnel credentials JSON changes but the tunnel UUID remains the same,
+recreate the Swarm secret during a planned maintenance window:
+
+```sh
+cd /opt/synctex
+docker stack rm synctex
+
+until [ -z "$(docker stack ps synctex 2>/dev/null)" ]; do
+  sleep 2
+done
+
+docker secret rm cloudflared_creds
+docker secret create cloudflared_creds ~/.cloudflared/<tunnel-uuid>.json
+scripts/deploy-stack.sh
+```
+
+If creating a completely new tunnel, update the UUID in Git first, merge the
+change, pull it on the Pi, recreate both `cloudflared_config` and
+`cloudflared_creds`, then redeploy.
+
+### DNS And OAuth
+
+The DNS route should point the apex hostname at the named tunnel:
+
+```sh
+cloudflared tunnel route dns synctex sync-tex.com
+```
+
+The GitHub OAuth app callback URL must match the public origin:
+
+```text
+https://sync-tex.com/auth/github/callback
+```
+
+After any domain or tunnel change, validate:
+
+```sh
+curl -fsS https://sync-tex.com/health
+docker service logs synctex_cloudflared --tail 100
+```
+
 ## Migrations
 
 `scripts/deploy-stack.sh` runs:
@@ -313,7 +486,7 @@ docker stack ps synctex
 Check gateway health from the production host:
 
 ```sh
-curl -fsS http://127.0.0.1/health
+curl -fsS https://sync-tex.com/health
 ```
 
 Service convergence is checked by:

--- a/frontend/src/api/collaborators.js
+++ b/frontend/src/api/collaborators.js
@@ -1,8 +1,6 @@
 // src/api/collaborators.js
 import { authFetch } from '../contexts/AuthContext';
 
-const API_HOST = import.meta.env.VITE_API_HOST || 'http://localhost:3000';
-
 // Generate a new collaborator link
 export const generateCollaboratorLink = async (projectId, accessLevel) => {
   const response = await authFetch(

--- a/frontend/src/api/editor.js
+++ b/frontend/src/api/editor.js
@@ -1,7 +1,5 @@
 import { authFetch } from '../contexts/AuthContext';
 
-const API_HOST = import.meta.env.VITE_API_HOST || 'http://localhost:3000';
-
 export const fetchProjectTree = async (projectId) => {
   const response = await authFetch(`/projects/v1/projects/${projectId}/tree`);
   if (!response.ok) {

--- a/frontend/src/api/projects.js
+++ b/frontend/src/api/projects.js
@@ -1,8 +1,7 @@
 import { authFetch } from '../contexts/AuthContext';
 
 // API endpoint configuration
-//const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:3001/api';
-const API_BASE_URL = 'http://localhost:3001/api';
+const API_BASE_URL = '/projects/v1';
 
 /**
  * Fetch all projects for the current user
@@ -113,7 +112,7 @@ export async function createProject(projectData) {
 export async function importProject(formData) {
   // For file uploads, don't set Content-Type - let browser set it with boundary
   const token = localStorage.getItem('auth_token');
-  
+
   const response = await fetch(`${API_BASE_URL}/projects/import`, {
     method: 'POST',
     headers: {

--- a/frontend/src/components/Dashboard/JoinProjectModal.jsx
+++ b/frontend/src/components/Dashboard/JoinProjectModal.jsx
@@ -11,7 +11,7 @@ const JoinProjectModal = ({ onClose }) => {
 
   const extractTokenFromLink = (link) => {
     // Handle various link formats:
-    // Full URL: http://localhost:3000/join/token123
+    // Full URL: https://sync-tex.com/join/token123
     // Partial: /join/token123
     // Just token: token123
     const urlMatch = link.match(/\/join\/([a-zA-Z0-9_-]+)$/);
@@ -73,7 +73,7 @@ const JoinProjectModal = ({ onClose }) => {
               id="invite-link"
               type="text"
               className="form-input"
-              placeholder="e.g., http://localhost:3000/join/abc123xyz"
+              placeholder="e.g., https://sync-tex.com/join/abc123xyz"
               value={inviteLink}
               onChange={(e) => setInviteLink(e.target.value)}
               disabled={loading}


### PR DESCRIPTION
# build/add-named-tunnel

## Summary
- Switches production Swarm ingress from cloudflared quick-tunnel mode to the named `sync-tex.com` tunnel using committed cloudflared config and externally managed Swarm config/secret objects.
- Removes the nginx host port binding so the tunnel is the only public ingress path, while keeping internal service-to-service HTTP URLs on the Swarm overlay network.
- Updates production-facing example URLs and frontend browser defaults to avoid hardcoded localhost HTTP references under the Cloudflare HTTPS origin.
- Expands the deployment runbook with first-time named tunnel setup, Docker config/secret lifecycle management, DNS/OAuth validation, and tunnel credential rotation guidance.

## Changes
### Commits
- `c2fd327` feat(api-gateway): switch swarm deploy to named cloudflare tunnel.
  Context: Replace the quick-tunnel cloudflared setup with a config-driven named tunnel using the committed Cloudflare tunnel UUID and Swarm-managed config and secret objects. Remove the nginx host port binding so cloudflared is the only public ingress, and update the example external URLs to use https://sync-tex.com.
- `2b015c3` fix(frontend): remove hardcoded localhost http references.
  Context: Drop browser-facing localhost API defaults that would cause mixed-content or incorrect origin behavior behind the production tunnel. Use the existing relative project API path and update join-link examples to match the HTTPS production domain.
- `5964c91` docs(agent): document named tunnel setup and maintenance.
  Context: Expand the Swarm deployment runbook with first-time Cloudflare tunnel bootstrap steps, required external Docker config and secret creation, validation commands, and the maintenance flow for updating or rotating named tunnel assets on the production host.

### Files
- `.env.example` (updated)
- `cloudflared/config.yml` (added)
- `docker-compose.swarm.yml` (updated)
- `docs/deployment-runbook.md` (updated)
- `frontend/src/api/collaborators.js` (updated)
- `frontend/src/api/editor.js` (updated)
- `frontend/src/api/projects.js` (updated)
- `frontend/src/components/Dashboard/JoinProjectModal.jsx` (updated)

## Testing
- `docker compose -f docker-compose.swarm.yml config`
- `git diff --check`
- `npm run build` from `frontend/`
