### PR TITLE
Fix/cloudflare secrets config

### DIFF
--- a/docker-compose.swarm.yml
+++ b/docker-compose.swarm.yml
@@ -284,7 +284,7 @@ services:
     secrets:
       - source: cloudflared_creds
         target: /etc/cloudflared/ffab8018-a347-428e-8bac-e1c74a7cde3d.json
-        mode: 0400
+        mode: 0444
     deploy:
       replicas: 1
       restart_policy:

--- a/docs/deployment-runbook.md
+++ b/docs/deployment-runbook.md
@@ -466,6 +466,12 @@ curl -fsS https://sync-tex.com/health
 docker service logs synctex_cloudflared --tail 100
 ```
 
+If `cloudflared` logs a permission error when reading the credentials file,
+confirm the `cloudflared_creds` secret mount in `docker-compose.swarm.yml` uses
+mode `0444`. Recent `cloudflare/cloudflared` images run as a non-root user, so
+a root-only `0400` secret mount can make the tunnel credentials unreadable even
+though the Swarm secret exists.
+
 ## Migrations
 
 `scripts/deploy-stack.sh` runs:


### PR DESCRIPTION
# fix/cloudflare-secrets-config

## Summary
- This branch fixes the Swarm `cloudflared` secret mount so current `cloudflare/cloudflared` images can read the tunnel credentials file as a non-root user.
- It updates the deployment runbook with the concrete symptom and the expected secret mode to check when `cloudflared` reports credential file permission errors.
- File-level impact: 2 updated.

## Changes
### Commits
- `4fd5110` fix(infra): update cloudflare secrets config.
  Context: Changes the `cloudflared_creds` secret mount mode from `0400` to `0444` and documents why that is required.

### Files
- `docker-compose.swarm.yml` (updated to mount `cloudflared_creds` with mode `0444`)
- `docs/deployment-runbook.md` (updated with a troubleshooting note for `cloudflared` credential permission failures)
