### PR TITLE
Fix/users db dead connection

### DIFF
--- a/users-service/models.py
+++ b/users-service/models.py
@@ -82,7 +82,11 @@ DATABASE_URL = os.getenv(
     "DATABASE_URL", "postgresql://postgres:password@localhost/users_service"
 )
 
-engine = create_engine(DATABASE_URL)
+engine = create_engine(
+    DATABASE_URL,
+    pool_pre_ping=True,
+    pool_recycle=1800,
+)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 


### PR DESCRIPTION
# fix/users-db-dead-connection

## Summary
- This branch packages 1 local commits across `users-service`.
- It hardens OAuth request handling against stale Postgres connections in `users-service`.
- File-level impact: 1 updated.
- Implementation context: enables SQLAlchemy `pool_pre_ping` and adds a 30 minute `pool_recycle` interval so dead or aging pooled connections are refreshed before request handling uses them.

## Changes
### Commits
- `22c7807` fix(users-service): harden postgres pooled connections for oauth requests.
  Context: Enables SQLAlchemy `pool_pre_ping` and a 30 minute recycle interval to reduce intermittent first-login OAuth failures caused by dead pooled database connections.

### Files
- `users-service/models.py` (updated to configure SQLAlchemy engine connection health checks and recycle behavior)
